### PR TITLE
Use just "4k" as scale option name

### DIFF
--- a/Pages/MoonlightSettings.xaml.cpp
+++ b/Pages/MoonlightSettings.xaml.cpp
@@ -34,7 +34,7 @@ MoonlightSettings::MoonlightSettings()
 	item->DataContext = "";
 	HostSelector->Items->Append(item);
 	AvailableCompositionScale->Append("Normal");
-	AvailableCompositionScale->Append("4k Xbox Series S/Xbox One S");
+	AvailableCompositionScale->Append("4k");
 
 	if (state->CompositionScale != "Normal") {
 		CompositionScaleIndex = 1;


### PR DESCRIPTION
When not in dev mode for me the 4k scale option still needs to be selected to work on Xbox Series X.