### PR TITLE
Host Wake-On-LAN

### DIFF
--- a/Pages/HostSelectorPage.xaml
+++ b/Pages/HostSelectorPage.xaml
@@ -17,6 +17,11 @@
                     <SymbolIcon Symbol="Setting" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
+            <MenuFlyoutItem x:Name="wakeHostButton" Click="wakeHostButton_Click" Text="Wake Host" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                <MenuFlyoutItem.Icon>
+                    <SymbolIcon Symbol="MapDrive" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
             <MenuFlyoutItem x:Name="removeHostButton" Click="removeHostButton_Click" Text="Remove Host" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
                 <MenuFlyoutItem.Icon>
                     <SymbolIcon Symbol="Remove" />

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -207,3 +207,9 @@ void moonlight_xbox_dx::HostSelectorPage::OnKeyDown(Platform::Object^ sender, Wi
 		CoreInputView::GetForCurrentView()->TryHide();
 	}
 }
+
+
+void moonlight_xbox_dx::HostSelectorPage::wakeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	State->WakeHost(currentHost);
+}

--- a/Pages/HostSelectorPage.xaml.h
+++ b/Pages/HostSelectorPage.xaml.h
@@ -42,5 +42,6 @@ namespace moonlight_xbox_dx
 		void SettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		bool continueFetch = false;
 		void OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
+		void wakeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -2,6 +2,9 @@
 #include "ApplicationState.h"
 #include <Utils.hpp>
 #include <nlohmann/json.hpp>
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#include <WinSock2.h>
+
 
 using namespace Windows::Storage;
 Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
@@ -38,6 +41,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
 					if (a.contains("computername")) h->ComputerName = Utils::StringFromStdString(a["computername"].get<std::string>());
 					if (a.contains("playaudioonpc")) h->PlayAudioOnPC = a["playaudioonpc"].get<bool>();
 					if (a.contains("enable_hdr")) h->EnableHDR = a["enable_hdr"].get<bool>();
+					if (a.contains("macaddress")) h->MacAddress = Utils::StringFromStdString(a["macaddress"].get<std::string>());
 					else h->ComputerName = h->LastHostname;
 					this->SavedHosts->Append(h);
 				}
@@ -125,4 +129,60 @@ moonlight_xbox_dx::ApplicationState^ __stateInstance;
 moonlight_xbox_dx::ApplicationState^ moonlight_xbox_dx::GetApplicationState() {
 	if (__stateInstance == nullptr)__stateInstance = ref new moonlight_xbox_dx::ApplicationState();
 	return __stateInstance;
+}
+
+void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
+{
+	if (host == nullptr || host->Connected) return;
+
+	if (host->MacAddress == nullptr || host->MacAddress == "00:00:00:00:00:00") {
+		Utils::Log("No recorded Mac address, the client and host must be connected at least once.\n");
+		return;
+	}
+
+	WSADATA wsa;
+	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+		Utils::Log("Websocket startup failed.\n");
+		return;
+	}
+
+	SOCKET s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (s == SOCKET_ERROR || s == INVALID_SOCKET) {
+		Utils::Log("Websocket creation failed.\n");
+		WSACleanup();
+		return;
+	}
+
+	sockaddr_in addr{};
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(9);
+	addr.sin_addr.s_addr = inet_addr(Utils::PlatformStringToStdString(host->LastHostname).data());
+
+	const char* macStr = Utils::PlatformStringToStdString(host->MacAddress).data();
+	char macHex[6]{};
+	for (int i = 0; i < 6; i++) {
+		char dummy[3] = "00";
+		for (int j = 0; j < 2; j++) {
+			dummy[j] = macStr[j + (i * 3)];
+		}
+
+		int num = strtol(dummy, NULL, 16);
+		                                                                                
+		macHex[i] = num;
+	}
+
+	char data[102];
+	memset(data, 0xff, 6);
+
+	for (int i = 1; i < 17; i++) {
+		memcpy(data + (i * 6), macHex, 6);
+	}
+
+	int status = sendto(s, data, (int)strlen(data) - 1, 0, (sockaddr*)&addr, sizeof(addr));
+	if (status == SOCKET_ERROR)
+		Utils::Log("Error sending Wake-On-Lan packet.\n");
+	else
+		Utils::Log("Wake-On-Lan packet sent.\n");
+
+	WSACleanup();
 }

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -149,7 +149,7 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 	SOCKET s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (s == SOCKET_ERROR || s == INVALID_SOCKET) {
-		Utils::Log("Websocket creation failed.\n");
+		Utils::Log("socket creation failed.\n");
 		WSACleanup();
 		return;
 	}

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -143,7 +143,7 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 	WSADATA wsa;
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
-		Utils::Log("Websocket startup failed.\n");
+		Utils::Log("socket startup failed.\n");
 		return;
 	}
 

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -133,12 +133,13 @@ moonlight_xbox_dx::ApplicationState^ moonlight_xbox_dx::GetApplicationState() {
 
 void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 {
-	if (host == nullptr || host->Connected) return;
-
+	// if (host == nullptr || host->Connected) return;
+	/*
 	if (host->MacAddress == nullptr || host->MacAddress == "00:00:00:00:00:00") {
 		Utils::Log("No recorded Mac address, the client and host must be connected at least once.\n");
 		return;
 	}
+	*/
 
 	WSADATA wsa;
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
@@ -152,14 +153,18 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 		WSACleanup();
 		return;
 	}
+	
+	int broadcast = 1;
 
-	sockaddr_in addr{};
+	struct sockaddr_in addr;
+
+	memset(&addr, 0, sizeof(struct sockaddr_in));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(9);
 	addr.sin_addr.s_addr = inet_addr(Utils::PlatformStringToStdString(host->LastHostname).data());
 
-	const char* macStr = Utils::PlatformStringToStdString(host->MacAddress).data();
-	char macHex[6]{};
+	std::string macStr = Utils::PlatformStringToStdString(host->MacAddress);
+	std::string macHex;
 	for (int i = 0; i < 6; i++) {
 		char dummy[3] = "00";
 		for (int j = 0; j < 2; j++) {
@@ -168,21 +173,33 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 		int num = strtol(dummy, NULL, 16);
 		                                                                                
-		macHex[i] = num;
+		macHex += num;
 	}
 
+	/*
 	char data[102];
 	memset(data, 0xff, 6);
 
 	for (int i = 1; i < 17; i++) {
 		memcpy(data + (i * 6), macHex, 6);
 	}
+	*/
+	std::string data(6, 0xFF);
+	for (int i = 0; i < 16; ++i) {
+		data += macHex;
+	}
 
-	int status = sendto(s, data, (int)strlen(data) - 1, 0, (sockaddr*)&addr, sizeof(addr));
-	if (status == SOCKET_ERROR)
+	const int optval = 1;
+	setsockopt(s, SOL_SOCKET, SO_BROADCAST, (char*) & optval, sizeof(optval));
+
+	int status = sendto(s, data.c_str(), data.length(), 0, (struct sockaddr*)&addr, sizeof(addr));
+	if (status == SOCKET_ERROR)	{
 		Utils::Log("Error sending Wake-On-Lan packet.\n");
-	else
+	}
+	else {
 		Utils::Log("Wake-On-Lan packet sent.\n");
+	}
 
+	closesocket(s);
 	WSACleanup();
 }

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -23,6 +23,7 @@ namespace moonlight_xbox_dx {
 		std::string autostartInstance = "";
 		bool enableKeyboard = false;
 		bool shouldAutoConnect = false;
+		void WakeHost(MoonlightHost^ host);
 		 
 	public:
 		//Thanks to https://phsucharee.wordpress.com/2013/06/19/data-binding-and-ccx-inotifypropertychanged/

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -360,6 +360,10 @@ Platform::String^ MoonlightClient::GetComputerName() {
 	return Utils::StringFromChars(serverData.serverName);
 }
 
+Platform::String^ MoonlightClient::GetMacAddress() {
+	return Utils::StringFromChars(serverData.macAddress);
+}
+
 void MoonlightClient::KeyDown(unsigned short v, char modifiers) {
 	LiSendKeyboardEvent2(v, KEY_ACTION_DOWN, modifiers, 0);
 }

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -360,7 +360,7 @@ Platform::String^ MoonlightClient::GetComputerName() {
 	return Utils::StringFromChars(serverData.serverName);
 }
 
-Platform::String^ MoonlightClient::GetMacAddress() {
+Platform::String^ MoonlightClient::GetServerMacAddress() {
 	return Utils::StringFromChars(serverData.macAddress);
 }
 

--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -38,7 +38,7 @@ namespace moonlight_xbox_dx {
 		void SendGuide(int controllerNumber, bool v);
 		Platform::String^ GetInstanceID();
 		Platform::String^ GetComputerName();
-		Platform::String^ GetMacAddress();
+		Platform::String^ GetServerMacAddress();
 		std::function<void(int)> OnStatusUpdate;
 		std::function<void()> OnCompleted;
 		std::function<void(bool)> SetHDR;

--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -38,6 +38,7 @@ namespace moonlight_xbox_dx {
 		void SendGuide(int controllerNumber, bool v);
 		Platform::String^ GetInstanceID();
 		Platform::String^ GetComputerName();
+		Platform::String^ GetMacAddress();
 		std::function<void(int)> OnStatusUpdate;
 		std::function<void()> OnCompleted;
 		std::function<void(bool)> SetHDR;

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -12,7 +12,10 @@ namespace moonlight_xbox_dx {
 			this->Paired = client->IsPaired();
 			this->CurrentlyRunningAppId = client->GetRunningAppID();
 			this->InstanceId = client->GetInstanceID();
-			if (this->Connected) this->ComputerName = client->GetComputerName();
+			if (this->Connected) {
+				this->ComputerName = client->GetComputerName();
+				this->MacAddress = client->GetMacAddress();
+			}
 		}
 		this->Loading = false;
 	}

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -14,12 +14,7 @@ namespace moonlight_xbox_dx {
 			this->InstanceId = client->GetInstanceID();
 			if (this->Connected) {
 				this->ComputerName = client->GetComputerName();
-
-				Platform::String^ macAddress = client->GetServerMacAddress();
-				if (macAddress != this->MacAddress) {
-					this->MacAddress = macAddress;
-					GetApplicationState()->UpdateFile();
-				}
+				this->MacAddress = client->GetServerMacAddress();
 			}
 		}
 		this->Loading = false;

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -14,7 +14,12 @@ namespace moonlight_xbox_dx {
 			this->InstanceId = client->GetInstanceID();
 			if (this->Connected) {
 				this->ComputerName = client->GetComputerName();
-				this->MacAddress = client->GetMacAddress();
+
+				Platform::String^ macAddress = client->GetServerMacAddress();
+				if (macAddress != this->MacAddress) {
+					this->MacAddress = macAddress;
+					GetApplicationState()->UpdateFile();
+				}
 			}
 		}
 		this->Loading = false;

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -11,6 +11,7 @@ namespace moonlight_xbox_dx {
         Platform::String^ instanceId;
         Platform::String^ lastHostname;
         Platform::String^ computerName;
+        Platform::String^ macAddress;
         bool paired;
         bool connected;
         bool loading = true;
@@ -201,6 +202,15 @@ namespace moonlight_xbox_dx {
             void set(bool value) {
                 this->enableHDR = value;
                 OnPropertyChanged("EnableHDR");
+            }
+        }
+
+        property Platform::String^ MacAddress 
+        {
+            Platform::String^ get() { return this->macAddress; }
+            void set(Platform::String^ value) {
+                this->macAddress = value;
+                OnPropertyChanged("MacAddress");
             }
         }
     };

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -240,6 +240,9 @@ static int load_serverinfo(PSERVER_DATA server, bool https) {
   if (xml_search(data->memory, data->size, "HttpsPort", &httpsPortText) != GS_OK)
     goto cleanup;
 
+  if (xml_search(data->memory, data->size, "mac", &server->macAddress) != GS_OK)
+      goto cleanup;
+
   if (xml_modelist(data->memory, data->size, &server->modes) != GS_OK)
     goto cleanup;
 
@@ -252,7 +255,7 @@ static int load_serverinfo(PSERVER_DATA server, bool https) {
   server->serverInfo.serverCodecModeSupport = serverCodecModeSupportText == NULL ? SCM_H264 : atoi(serverCodecModeSupportText);
   server->serverMajorVersion = atoi(server->serverInfo.serverInfoAppVersion);
   server->isNvidiaSoftware = strstr(stateText, "MJOLNIR") != NULL;
-
+ 
   server->httpsPort = atoi(httpsPortText);
   if (!server->httpsPort)
     server->httpsPort = 47984;

--- a/libgamestream/client.h
+++ b/libgamestream/client.h
@@ -42,6 +42,7 @@ typedef struct _SERVER_DATA {
   unsigned short httpsPort;
   char* serverName;
   char* uniqueId;
+  char* macAddress;
 } SERVER_DATA, *PSERVER_DATA;
 
 int gs_init(PSERVER_DATA server, char* address, unsigned short httpPort, const char *keyDirectory, int logLevel, bool unsupported);


### PR DESCRIPTION
Add an option to wake host by sending a magic packet to its last known IP and the usual broadcast IPs.

I had to retrieve the MacAddress from the server info, so this will only work after the host / client have been connected since this update. Warnings and errors are just sent to logging, wasn't sure if we should pop an error message or if we should hide the button if the host is connected / reachable.

Magic packet is constructed with 6 0xFF chars followed by 16 mac addresses (in base 16 decimal). This can't be tested using a local machine as the server info doesn't retrieve the mac address, but tested using my laptop fine.

Feel free to edit and thanks for creating this project.