### PR TITLE
build(submodules): fix submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third_party/moonlight-common-c"]
 	path = third_party/moonlight-common-c
-	url = https://github.com/moonlight-stream/moonlight-common-c
+	url = https://github.com/moonlight-stream/moonlight-common-c.git
 [submodule "vcpkg"]
 	path = vcpkg
-	url = git@github.com:microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg.git


### PR DESCRIPTION
Submodules failed to initialize with the following errors.

```txt
\moonlight-xbox>git submodule update --init --recursive
Cloning into 'C:/Users/ReenigneArcher/Documents/GitHub/ReenigneArcher/moonlight-xbox/vcpkg'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:microsoft/vcpkg.git' into submodule path 'C:/Users/ReenigneArcher/Documents/GitHub/ReenigneArcher/moonlight-xbox/vcpkg' failed
Failed to clone 'vcpkg'. Retry scheduled
Cloning into 'C:/Users/ReenigneArcher/Documents/GitHub/ReenigneArcher/moonlight-xbox/vcpkg'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:microsoft/vcpkg.git' into submodule path 'C:/Users/ReenigneArcher/Documents/GitHub/ReenigneArcher/moonlight-xbox/vcpkg' failed
Failed to clone 'vcpkg' a second time, aborting
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated submodule URLs to use `https` instead of `git` for fetching external dependencies, ensuring more secure and reliable connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->