### PR TITLE
Mitigate corruption, ask for an IDR every X frames

### DIFF
--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -14,7 +14,9 @@ extern "C" {
 #include<libswscale/swscale.h>
 #include<libavutil/hwcontext_d3d11va.h>
 }
+
 #define DECODER_BUFFER_SIZE 1048576
+#define MAX_DELAY_BETWEEN_IDR_FRAMES 1000
 
 namespace moonlight_xbox_dx {
 
@@ -163,6 +165,9 @@ namespace moonlight_xbox_dx {
 			Utils::Log("Using hack for Xbox One Consoles");
 			hackWait = true;
 		}
+
+		framesSinceLastIDR = 0;
+
 		return 0;
 	}
 
@@ -205,12 +210,21 @@ namespace moonlight_xbox_dx {
 			entry = entry->next;
 		}
 		int err;
+
 		err = Decode(ffmpeg_buffer, length);
 		if (err < 0) {
 			LiCompleteVideoFrame(frameHandle, DR_NEED_IDR);
 			return false;
 		}
+
 		LiCompleteVideoFrame(frameHandle, DR_OK);
+
+		if (framesSinceLastIDR++ >= MAX_DELAY_BETWEEN_IDR_FRAMES) {
+			// This mitigates the issue where the video slowly gets more corrupt
+			LiRequestIdrFrame();
+			framesSinceLastIDR = 0;
+		}
+
 		return true;
 	}
 

--- a/Streaming/FFmpegDecoder.h
+++ b/Streaming/FFmpegDecoder.h
@@ -44,6 +44,7 @@ namespace moonlight_xbox_dx
 		AVFrame** dec_frames;
 		AVFrame** ready_frames;
 		int next_frame, current_frame;
+		int framesSinceLastIDR;
 		std::shared_ptr<DX::DeviceResources> resources;
 	};
 }


### PR DESCRIPTION
To mitigate #117 (Compression artifacts forming when left on the same scene for a while), request an IDR frame from the host every 1000 packets. This seems to reset the decoder well enough to completely avoid slow corruption problem, but shouldn't add too much extra bandwidth.

Unless I'm missing something, Sunshine never sends I or IDR frames after initially establishing the stream unless it's specifically asked to by the client.

(This is a hacky mitigation, not a proper fix. It works but it's not the ideal fix. Since this only seems to happen on this platform, I'm guessing either we're touching memory we shouldn't / in a way we shouldn't, or ffmpeg has a hardware acceleration bug on this platform. Tracking down the root cause is a pain though, especially with UWP's limitations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved video decoding stability by implementing a threshold for requesting IDR frames, enhancing performance during frame corruption scenarios.

- **Bug Fixes**
  - Enhanced handling of frame management to prevent video output issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->