### PR TITLE
Fix 120 FPS

### DIFF
--- a/Common/DeviceResources.cpp
+++ b/Common/DeviceResources.cpp
@@ -276,7 +276,7 @@ void DX::DeviceResources::CreateWindowSizeDependentResources()
 		//Check moonlight-stream/moonlight-qt/app/streaming/video/ffmpeg-renderers/d3d11va.cpp for rationale
 		swapChainDesc.BufferCount = 5;							
 		swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-		swapChainDesc.Flags = 0;
+		swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
 		swapChainDesc.Scaling = DXGI_SCALING_STRETCH;
 		swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -46,7 +46,7 @@ int MoonlightClient::StartStreaming(std::shared_ptr<DX::DeviceResources> res, St
 	config.width = sConfig->width;
 	config.height = sConfig->height;
 	config.bitrate = sConfig->bitrate;
-	config.clientRefreshRateX100 = 60 * 100;
+	config.clientRefreshRateX100 = sConfig->FPS * 100;
 	config.colorRange = COLOR_RANGE_LIMITED;  //TODO Make me configurable
 	config.encryptionFlags = 0;
 	config.fps = sConfig->FPS;


### PR DESCRIPTION
Fixes #133 (120hz Doesn't Work)

`swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;` doesn't appear to actually cause rendering to fall off vsync, as long as you don't add ALLOW_TEARING to the Present call, but it does seem to uncap the rendering framerate from 60 Hz to whatever the display refresh rate is.

Tested at 60 and 120 Hz, seems to work fine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved rendering performance by allowing the application to present frames without waiting for vertical sync, enhancing visual responsiveness.
	- Introduced a dynamic refresh rate for streaming, allowing users to configure the refresh rate based on their preferred frames per second.
  
- **Bug Fixes**
	- Resolved fixed refresh rate limitation, now enabling user-defined FPS settings for a more flexible streaming experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->