### PR TITLE
Enabled intra refresh

### DIFF
--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -295,7 +295,7 @@ namespace moonlight_xbox_dx {
 		decoder_callbacks_sdl.stop = stopCallback;
 		decoder_callbacks_sdl.cleanup = cleanupCallback;
 		decoder_callbacks_sdl.submitDecodeUnit = NULL;
-		decoder_callbacks_sdl.capabilities = CAPABILITY_PULL_RENDERER;
+		decoder_callbacks_sdl.capabilities = CAPABILITY_PULL_RENDERER | CAPABILITY_INTRA_REFRESH;
 		return decoder_callbacks_sdl;
 	}
 


### PR DESCRIPTION
Ask for Intra-refresh when setting up the client.

This PR completes the PR of:

moonlight-common-c: https://github.com/moonlight-stream/moonlight-common-c/pull/97
Sunshine: https://github.com/LizardByte/Sunshine/pull/3415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced decoder functionality with support for intra-refresh capabilities.
  
- **Chores**
	- Updated the commit identifier for the `moonlight-common-c` subproject.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->