### PR TITLE
Wake On Lan

### DIFF
--- a/Pages/AddHost.xaml
+++ b/Pages/AddHost.xaml
@@ -1,0 +1,23 @@
+﻿<ContentDialog
+    x:Class="moonlight_xbox_dx.AddHost"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:moonlight_xbox_dx"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Add Host"
+    PrimaryButtonText="Add"
+    SecondaryButtonText="Cancel"
+    PrimaryButtonClick="OnNewHostDialogPrimaryClick"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <StackPanel>
+        <TextBox Header="Host" x:Name="dialogIPAddressTextBox" PlaceholderText="Host"
+                 HorizontalAlignment="Stretch"/>
+
+        <TextBox Header="Port" x:Name="dialogPortTextBox" PlaceholderText="Port (Optional)"
+                 Margin="0,15,0,10" HorizontalAlignment="Stretch"
+                 InputScope="Number"/>
+    </StackPanel>
+</ContentDialog>

--- a/Pages/AddHost.xaml.cpp
+++ b/Pages/AddHost.xaml.cpp
@@ -1,0 +1,62 @@
+﻿//
+// AddHost.xaml.cpp
+// Implementation of the AddHost class
+//
+
+#include "pch.h"
+#include "AddHost.xaml.h"
+#include <State\MoonlightClient.h>
+#include "Utils.hpp"
+
+using namespace moonlight_xbox_dx;
+
+using namespace Platform;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Data;
+using namespace Windows::UI::Xaml::Input;
+using namespace Windows::UI::Xaml::Media;
+using namespace Windows::UI::Xaml::Navigation;
+using namespace Windows::UI::ViewManagement::Core;
+
+// The Content Dialog item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+AddHost::AddHost()
+{
+	state = GetApplicationState();
+	InitializeComponent();
+}
+
+void moonlight_xbox_dx::AddHost::OnNewHostDialogPrimaryClick(Windows::UI::Xaml::Controls::ContentDialog^ sender, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^ args)
+{
+	sender->IsPrimaryButtonEnabled = false;
+
+	Platform::String^ ipAddress = dialogIPAddressTextBox->Text;
+	Platform::String^ port = dialogPortTextBox->Text;
+
+	auto def = args->GetDeferral();
+	Concurrency::create_task([def, ipAddress, port, this, args, sender]() {
+		bool status = state->AddHost(ipAddress, port);
+		if (!status) {
+			Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([sender, this, ipAddress, def, args]() {
+				args->Cancel = true;
+				sender->Content = L"Failed to Connect to " + ipAddress;
+				def->Complete();
+				}));
+			return;
+		}
+		Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([def]() {
+			def->Complete();
+			}));
+		});
+}
+
+void moonlight_xbox_dx::AddHost::OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
+{
+	if (e->Key == Windows::System::VirtualKey::Enter) {
+		CoreInputView::GetForCurrentView()->TryHide();
+	}
+}

--- a/Pages/AddHost.xaml.h
+++ b/Pages/AddHost.xaml.h
@@ -1,0 +1,29 @@
+﻿//
+// AddHost.xaml.h
+// Declaration of the AddHost class
+//
+
+#pragma once
+
+#include "Pages\AddHost.g.h"
+#include "State\ApplicationState.h"
+
+using namespace Windows::UI::Core;
+namespace moonlight_xbox_dx
+{
+	[Windows::Foundation::Metadata::WebHostHidden]
+	public ref class AddHost sealed
+	{
+	public:
+		AddHost();
+		property ApplicationState^ State {
+			ApplicationState^ get() {
+				return this->state;
+			}
+		}
+	private:
+		ApplicationState^ state;
+		void OnNewHostDialogPrimaryClick(Windows::UI::Xaml::Controls::ContentDialog^ sender, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^ args);
+		void OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
+	};
+}

--- a/Pages/AppPage.xaml.cpp
+++ b/Pages/AppPage.xaml.cpp
@@ -59,7 +59,7 @@ void moonlight_xbox_dx::AppPage::AppsGrid_ItemClick(Platform::Object^ sender, Wi
 
 void AppPage::Connect(int appId) {
 	StreamConfiguration^ config = ref new StreamConfiguration();
-	config->hostname = host->LastHostname;
+	config->hostname = host->Hostname;
 	config->appID = appId;
 	config->width = host->Resolution->Width;
 	config->height = host->Resolution->Height;
@@ -94,7 +94,7 @@ void moonlight_xbox_dx::AppPage::closeAppButton_Click(Platform::Object^ sender, 
 {
 	auto client = new MoonlightClient();
 	char ipAddressStr[2048];
-	wcstombs_s(NULL, ipAddressStr, Host->LastHostname->Data(), 2047);
+	wcstombs_s(NULL, ipAddressStr, Host->Hostname->Data(), 2047);
 	int status = client->Connect(ipAddressStr);
 	if (status == 0)client->StopApp();
 	host->UpdateStats();

--- a/Pages/HostSelectorPage.xaml
+++ b/Pages/HostSelectorPage.xaml
@@ -17,6 +17,11 @@
                     <SymbolIcon Symbol="Setting" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
+            <MenuFlyoutItem x:Name="wakeHostButton" Click="wakeHostButton_Click" Text="Wake Host" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                <MenuFlyoutItem.Icon>
+                    <SymbolIcon Symbol="MapDrive" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
             <MenuFlyoutItem x:Name="removeHostButton" Click="removeHostButton_Click" Text="Remove Host" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
                 <MenuFlyoutItem.Icon>
                     <SymbolIcon Symbol="Remove" />

--- a/Pages/HostSelectorPage.xaml
+++ b/Pages/HostSelectorPage.xaml
@@ -12,14 +12,14 @@
     >
     <FlyoutBase.AttachedFlyout>
         <MenuFlyout x:Name="ActionsFlyout" AllowFocusOnInteraction="false" Placement="TopEdgeAlignedRight">
-            <MenuFlyoutItem x:Name="hostSettingsButton" Click="hostSettingsButton_Click" Text="Host Settings" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
-                <MenuFlyoutItem.Icon>
-                    <SymbolIcon Symbol="Setting" />
-                </MenuFlyoutItem.Icon>
-            </MenuFlyoutItem>
             <MenuFlyoutItem x:Name="wakeHostButton" Click="wakeHostButton_Click" Text="Wake Host" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
                 <MenuFlyoutItem.Icon>
                     <SymbolIcon Symbol="MapDrive" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
+            <MenuFlyoutItem x:Name="hostSettingsButton" Click="hostSettingsButton_Click" Text="Host Settings" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                <MenuFlyoutItem.Icon>
+                    <SymbolIcon Symbol="Setting" />
                 </MenuFlyoutItem.Icon>
             </MenuFlyoutItem>
             <MenuFlyoutItem x:Name="removeHostButton" Click="removeHostButton_Click" Text="Remove Host" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -56,14 +56,14 @@ void moonlight_xbox_dx::HostSelectorPage::NewHostButton_Click(Platform::Object^ 
 void moonlight_xbox_dx::HostSelectorPage::OnNewHostDialogPrimaryClick(Windows::UI::Xaml::Controls::ContentDialog^ sender, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^ args)
 {
 	sender->IsPrimaryButtonEnabled = false;
-	Platform::String^ hostname = dialogHostnameTextBox->Text;
+	Platform::String^ ipAddress = dialogHostnameTextBox->Text;
 	auto def = args->GetDeferral();
-	Concurrency::create_task([def, hostname, this, args, sender]() {
-		bool status = state->AddHost(hostname);
+	Concurrency::create_task([def, ipAddress, this, args, sender]() {
+		bool status = state->AddHost(ipAddress, "");
 		if (!status) {
-			Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([sender, this, hostname, def, args]() {
+			Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([sender, this, ipAddress, def, args]() {
 				args->Cancel = true;
-				sender->Content = L"Failed to Connect to " + hostname;
+				sender->Content = L"Failed to Connect to " + ipAddress;
 				def->Complete();
 				}));
 			return;
@@ -198,7 +198,7 @@ void HostSelectorPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEv
 			}
 			Sleep(5000);
 		}
-		});
+	});
 }
 
 void moonlight_xbox_dx::HostSelectorPage::OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -207,3 +207,9 @@ void moonlight_xbox_dx::HostSelectorPage::OnKeyDown(Platform::Object^ sender, Wi
 		CoreInputView::GetForCurrentView()->TryHide();
 	}
 }
+
+
+void moonlight_xbox_dx::HostSelectorPage::wakeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	State->WakeHost(currentHost);
+}

--- a/Pages/HostSelectorPage.xaml.h
+++ b/Pages/HostSelectorPage.xaml.h
@@ -42,5 +42,6 @@ namespace moonlight_xbox_dx
 		void SettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		bool continueFetch = false;
 		void OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
+		void wakeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }

--- a/Pages/HostSelectorPage.xaml.h
+++ b/Pages/HostSelectorPage.xaml.h
@@ -31,8 +31,6 @@ namespace moonlight_xbox_dx
 	private:
 		ApplicationState ^state;
 		void NewHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-		void OnNewHostDialogPrimaryClick(Windows::UI::Xaml::Controls::ContentDialog^ sender, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^ args);
-		Windows::UI::Xaml::Controls::TextBox ^dialogHostnameTextBox;
 		void GridView_ItemClick(Platform::Object^ sender, Windows::UI::Xaml::Controls::ItemClickEventArgs^ e);
 		void StartPairing(MoonlightHost^ host);
 		void removeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/Pages/HostSettingsPage.xaml
+++ b/Pages/HostSettingsPage.xaml
@@ -17,7 +17,7 @@
             </Button>
             <StackPanel Margin="16 0 0 0">
                 <TextBlock Text="{x:Bind Host.ComputerName}"></TextBlock>
-                <TextBlock Text="{x:Bind Host.LastHostname}"></TextBlock>
+                <TextBlock Text="{x:Bind Host.Hostname}"></TextBlock>
             </StackPanel>
         </StackPanel>
         <Grid RowSpacing="8">

--- a/Pages/MoonlightSettings.xaml.cpp
+++ b/Pages/MoonlightSettings.xaml.cpp
@@ -41,7 +41,7 @@ MoonlightSettings::MoonlightSettings()
 	for (int i = 0; i < state->SavedHosts->Size;i++) {
 		auto host = state->SavedHosts->GetAt(i);
 		auto item = ref new ComboBoxItem();
-		item->Content = host->LastHostname;
+		item->Content = host->Hostname;
 		item->DataContext = host->InstanceId;
 		HostSelector->Items->Append(item);
 		if (host->InstanceId->Equals(iid)) {

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -2,6 +2,9 @@
 #include "ApplicationState.h"
 #include <Utils.hpp>
 #include <nlohmann/json.hpp>
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#include <WinSock2.h>
+
 
 using namespace Windows::Storage;
 Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
@@ -38,6 +41,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
 					if (a.contains("computername")) h->ComputerName = Utils::StringFromStdString(a["computername"].get<std::string>());
 					if (a.contains("playaudioonpc")) h->PlayAudioOnPC = a["playaudioonpc"].get<bool>();
 					if (a.contains("enable_hdr")) h->EnableHDR = a["enable_hdr"].get<bool>();
+					if (a.contains("macaddress")) h->MacAddress = Utils::StringFromStdString(a["macaddress"].get<std::string>());
 					else h->ComputerName = h->LastHostname;
 					this->SavedHosts->Append(h);
 				}
@@ -125,4 +129,60 @@ moonlight_xbox_dx::ApplicationState^ __stateInstance;
 moonlight_xbox_dx::ApplicationState^ moonlight_xbox_dx::GetApplicationState() {
 	if (__stateInstance == nullptr)__stateInstance = ref new moonlight_xbox_dx::ApplicationState();
 	return __stateInstance;
+}
+
+void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
+{
+	if (host == nullptr || host->Connected) return;
+
+	if (host->MacAddress == nullptr || host->MacAddress == "00:00:00:00:00:00") {
+		Utils::Log("No recorded Mac address, the client and host must be connected at least once.\n");
+		return;
+	}
+
+	WSADATA wsa;
+	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+		Utils::Log("Websocket startup failed.\n");
+		return;
+	}
+
+	SOCKET s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (s == SOCKET_ERROR || s == INVALID_SOCKET) {
+		Utils::Log("Websocket creation failed.\n");
+		WSACleanup();
+		return;
+	}
+
+	sockaddr_in addr{};
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(9);
+	addr.sin_addr.s_addr = inet_addr(Utils::PlatformStringToStdString(host->LastHostname).data());
+
+	const char* macStr = Utils::PlatformStringToStdString(host->MacAddress).data();
+	char macHex[6]{};
+	for (int i = 0; i < 6; i++) {
+		char dummy[3] = "00";
+		for (int j = 0; j < 2; j++) {
+			dummy[j] = macStr[j + (i * 3)];
+		}
+
+		int num = strtol(dummy, NULL, 16);
+		                                                                                
+		macHex[i] = num;
+	}
+
+	char data[102];
+	memset(data, 0xff, 6);
+
+	for (int i = 1; i < 17; i++) {
+		memcpy(data + (i * 6), macHex, 6);
+	}
+
+	int status = sendto(s, data, (int)strlen(data) - 1, 0, (sockaddr*)&addr, sizeof(addr));
+	if (status == SOCKET_ERROR)
+		Utils::Log("Error sending Wake-On-Lan packet.\n");
+	else
+		Utils::Log("Wake-On-Lan packet sent.\n");
+
+	WSACleanup();
 }

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -149,7 +149,7 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 	SOCKET s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (s == SOCKET_ERROR || s == INVALID_SOCKET) {
-		Utils::Log("Websocket creation failed.\n");
+		Utils::Log("socket creation failed.\n");
 		WSACleanup();
 		return;
 	}

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -4,7 +4,7 @@
 #include <nlohmann/json.hpp>
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <WinSock2.h>
-#include <ws2tcpip.h>
+#include <WS2tcpip.h>
 #include <sstream>
 
 using namespace Windows::Storage;
@@ -168,10 +168,19 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 		return;
 	}
 
+	
 	if (inet_addr(hostIP.c_str()) == -1)
 	{
 		Utils::Log("Given IP Address is not Ipv4. Resolving...\n");
 		struct hostent* he = gethostbyname(hostIP.c_str());
+		
+		if (!he) {
+			Utils::Log("gethostbyname failed. Could not resolve the hostname.\n");
+			WSACleanup();
+			return;
+
+		}
+
 		hostIP = inet_ntoa(*(struct in_addr*)he->h_addr_list[0]);
 
 		if (inet_addr(hostIP.c_str()) == -1)

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -143,7 +143,7 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 	WSADATA wsa;
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
-		Utils::Log("Websocket startup failed.\n");
+		Utils::Log("socket startup failed.\n");
 		return;
 	}
 

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -133,12 +133,13 @@ moonlight_xbox_dx::ApplicationState^ moonlight_xbox_dx::GetApplicationState() {
 
 void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 {
-	if (host == nullptr || host->Connected) return;
-
+	// if (host == nullptr || host->Connected) return;
+	/*
 	if (host->MacAddress == nullptr || host->MacAddress == "00:00:00:00:00:00") {
 		Utils::Log("No recorded Mac address, the client and host must be connected at least once.\n");
 		return;
 	}
+	*/
 
 	WSADATA wsa;
 	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
@@ -152,14 +153,18 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 		WSACleanup();
 		return;
 	}
+	
+	int broadcast = 1;
 
-	sockaddr_in addr{};
+	struct sockaddr_in addr;
+
+	memset(&addr, 0, sizeof(struct sockaddr_in));
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(9);
 	addr.sin_addr.s_addr = inet_addr(Utils::PlatformStringToStdString(host->LastHostname).data());
 
-	const char* macStr = Utils::PlatformStringToStdString(host->MacAddress).data();
-	char macHex[6]{};
+	std::string macStr = Utils::PlatformStringToStdString(host->MacAddress);
+	std::string macHex;
 	for (int i = 0; i < 6; i++) {
 		char dummy[3] = "00";
 		for (int j = 0; j < 2; j++) {
@@ -168,21 +173,33 @@ void moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 		int num = strtol(dummy, NULL, 16);
 		                                                                                
-		macHex[i] = num;
+		macHex += num;
 	}
 
+	/*
 	char data[102];
 	memset(data, 0xff, 6);
 
 	for (int i = 1; i < 17; i++) {
 		memcpy(data + (i * 6), macHex, 6);
 	}
+	*/
+	std::string data(6, 0xFF);
+	for (int i = 0; i < 16; ++i) {
+		data += macHex;
+	}
 
-	int status = sendto(s, data, (int)strlen(data) - 1, 0, (sockaddr*)&addr, sizeof(addr));
-	if (status == SOCKET_ERROR)
+	const int optval = 1;
+	setsockopt(s, SOL_SOCKET, SO_BROADCAST, (char*) & optval, sizeof(optval));
+
+	int status = sendto(s, data.c_str(), data.length(), 0, (struct sockaddr*)&addr, sizeof(addr));
+	if (status == SOCKET_ERROR)	{
 		Utils::Log("Error sending Wake-On-Lan packet.\n");
-	else
+	}
+	else {
 		Utils::Log("Wake-On-Lan packet sent.\n");
+	}
 
+	closesocket(s);
 	WSACleanup();
 }

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -17,7 +17,7 @@ namespace moonlight_xbox_dx {
 		bool alternateCombination;
 	internal:
 		Concurrency::task<void> Init();
-		bool AddHost(Platform::String^ hostname);
+		bool AddHost(Platform::String^ ipAddress, Platform::String^ port);
 		Concurrency::task<void> UpdateFile();
 		void RemoveHost(MoonlightHost^ host);
 		std::string autostartInstance = "";

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -23,7 +23,8 @@ namespace moonlight_xbox_dx {
 		std::string autostartInstance = "";
 		bool enableKeyboard = false;
 		bool shouldAutoConnect = false;
-		void WakeHost(MoonlightHost^ host);
+		bool WakeHost(MoonlightHost^ host);
+		std::pair<std::string, int> split_ip_port(const std::string& address);
 		 
 	public:
 		//Thanks to https://phsucharee.wordpress.com/2013/06/19/data-binding-and-ccx-inotifypropertychanged/

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -23,6 +23,7 @@ namespace moonlight_xbox_dx {
 		std::string autostartInstance = "";
 		bool enableKeyboard = false;
 		bool shouldAutoConnect = false;
+		void WakeHost(MoonlightHost^ host);
 		 
 	public:
 		//Thanks to https://phsucharee.wordpress.com/2013/06/19/data-binding-and-ccx-inotifypropertychanged/

--- a/State/MDNSHandler.cpp
+++ b/State/MDNSHandler.cpp
@@ -66,7 +66,6 @@ ip_address_to_string(char* buffer, size_t capacity, const struct sockaddr* addr,
 	return ipv4_address_to_string(buffer, capacity, (const struct sockaddr_in*)addr, addrlen);
 }
 
-
 // Callback handling parsing answers to queries sent
 static int
 query_callback(int sock, const struct sockaddr* from, size_t addrlen, mdns_entry_type_t entry,
@@ -95,15 +94,14 @@ query_callback(int sock, const struct sockaddr* from, size_t addrlen, mdns_entry
 		
 	}
 	if (ports.count(key) && hostnames.count(key)) {
-		auto hostname = hostnames[key];
-		auto hostnamePlusPort = Utils::StringFromStdString(hostname) + ":" + ports[key];
-		GetApplicationState()->AddHost(hostnamePlusPort);
+		auto hostname = Utils::StringFromStdString(hostnames[key]);
+		auto port = ports[key];
+		GetApplicationState()->AddHost(hostname, port.ToString());
 		hostnames.erase(key);
 		ports.erase(key);
 	}
 	return 0;
 }
-
 
 void init_mdns() {
 	WSADATA wsaData;

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -360,6 +360,10 @@ Platform::String^ MoonlightClient::GetComputerName() {
 	return Utils::StringFromChars(serverData.serverName);
 }
 
+Platform::String^ MoonlightClient::GetMacAddress() {
+	return Utils::StringFromChars(serverData.macAddress);
+}
+
 void MoonlightClient::KeyDown(unsigned short v, char modifiers) {
 	LiSendKeyboardEvent2(v, KEY_ACTION_DOWN, modifiers, 0);
 }

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -360,7 +360,7 @@ Platform::String^ MoonlightClient::GetComputerName() {
 	return Utils::StringFromChars(serverData.serverName);
 }
 
-Platform::String^ MoonlightClient::GetMacAddress() {
+Platform::String^ MoonlightClient::GetServerMacAddress() {
 	return Utils::StringFromChars(serverData.macAddress);
 }
 

--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -38,7 +38,7 @@ namespace moonlight_xbox_dx {
 		void SendGuide(int controllerNumber, bool v);
 		Platform::String^ GetInstanceID();
 		Platform::String^ GetComputerName();
-		Platform::String^ GetMacAddress();
+		Platform::String^ GetServerMacAddress();
 		std::function<void(int)> OnStatusUpdate;
 		std::function<void()> OnCompleted;
 		std::function<void(bool)> SetHDR;

--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -38,6 +38,7 @@ namespace moonlight_xbox_dx {
 		void SendGuide(int controllerNumber, bool v);
 		Platform::String^ GetInstanceID();
 		Platform::String^ GetComputerName();
+		Platform::String^ GetMacAddress();
 		std::function<void(int)> OnStatusUpdate;
 		std::function<void()> OnCompleted;
 		std::function<void(bool)> SetHDR;

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -12,7 +12,10 @@ namespace moonlight_xbox_dx {
 			this->Paired = client->IsPaired();
 			this->CurrentlyRunningAppId = client->GetRunningAppID();
 			this->InstanceId = client->GetInstanceID();
-			if (this->Connected) this->ComputerName = client->GetComputerName();
+			if (this->Connected) {
+				this->ComputerName = client->GetComputerName();
+				this->MacAddress = client->GetMacAddress();
+			}
 		}
 		this->Loading = false;
 	}

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -14,12 +14,7 @@ namespace moonlight_xbox_dx {
 			this->InstanceId = client->GetInstanceID();
 			if (this->Connected) {
 				this->ComputerName = client->GetComputerName();
-
-				Platform::String^ macAddress = client->GetServerMacAddress();
-				if (macAddress != this->MacAddress) {
-					this->MacAddress = macAddress;
-					GetApplicationState()->UpdateFile();
-				}
+				this->MacAddress = client->GetServerMacAddress();
 			}
 		}
 		this->Loading = false;

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -23,7 +23,7 @@ namespace moonlight_xbox_dx {
 	int MoonlightHost::Connect()
 	{
 		client = new MoonlightClient();
-		Platform::String^ ipAddress = this->lastHostname;
+		Platform::String^ ipAddress = this->hostname;
 		char ipAddressStr[2048];
 		wcstombs_s(NULL, ipAddressStr, ipAddress->Data(), 2047);
 		return client->Connect(ipAddressStr);

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -14,7 +14,12 @@ namespace moonlight_xbox_dx {
 			this->InstanceId = client->GetInstanceID();
 			if (this->Connected) {
 				this->ComputerName = client->GetComputerName();
-				this->MacAddress = client->GetMacAddress();
+
+				Platform::String^ macAddress = client->GetServerMacAddress();
+				if (macAddress != this->MacAddress) {
+					this->MacAddress = macAddress;
+					GetApplicationState()->UpdateFile();
+				}
 			}
 		}
 		this->Loading = false;

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -11,6 +11,7 @@ namespace moonlight_xbox_dx {
         Platform::String^ instanceId;
         Platform::String^ lastHostname;
         Platform::String^ computerName;
+        Platform::String^ macAddress;
         bool paired;
         bool connected;
         bool loading = true;
@@ -201,6 +202,15 @@ namespace moonlight_xbox_dx {
             void set(bool value) {
                 this->enableHDR = value;
                 OnPropertyChanged("EnableHDR");
+            }
+        }
+
+        property Platform::String^ MacAddress 
+        {
+            Platform::String^ get() { return this->macAddress; }
+            void set(Platform::String^ value) {
+                this->macAddress = value;
+                OnPropertyChanged("MacAddress");
             }
         }
     };

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -10,6 +10,8 @@ namespace moonlight_xbox_dx {
     private:
         Platform::String^ instanceId;
         Platform::String^ lastHostname;
+        Platform::String^ ipAddress;
+        Platform::String^ port;
         Platform::String^ computerName;
         Platform::String^ macAddress;
         bool paired;
@@ -30,8 +32,10 @@ namespace moonlight_xbox_dx {
         //Thanks to https://phsucharee.wordpress.com/2013/06/19/data-binding-and-ccx-inotifypropertychanged/
         virtual event Windows::UI::Xaml::Data::PropertyChangedEventHandler^ PropertyChanged;
         void OnPropertyChanged(Platform::String^ propertyName);
-        MoonlightHost(Platform::String ^host) {
-            lastHostname = host;
+        MoonlightHost(Platform::String ^ipAddress, Platform::String ^port) {
+            this->ipAddress = ipAddress;
+            this->port = port;
+            lastHostname = ipAddress + ":" + port;
             resolution = ref new ScreenResolution(1280, 720);
             loading = true;
         }
@@ -45,6 +49,22 @@ namespace moonlight_xbox_dx {
             void set(Platform::String^ value) {
                 this->instanceId = value;
                 OnPropertyChanged("InstanceId");
+            }
+        }
+        property Platform::String^ IPAddress
+        {
+            Platform::String^ get() { return this->ipAddress; }
+            void set(Platform::String ^ value) {
+                this->ipAddress = value;
+                OnPropertyChanged("IPAddress");
+            }
+        }
+        property Platform::String^ Port
+        {
+            Platform::String^ get() { return this->port; }
+            void set(Platform::String ^ value) {
+                this->port = value;
+                OnPropertyChanged("Port");
             }
         }
         property Platform::String^ LastHostname

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -9,7 +9,7 @@ namespace moonlight_xbox_dx {
     {
     private:
         Platform::String^ instanceId;
-        Platform::String^ lastHostname;
+        Platform::String^ hostname;
         Platform::String^ ipAddress;
         Platform::String^ port;
         Platform::String^ computerName;
@@ -35,7 +35,7 @@ namespace moonlight_xbox_dx {
         MoonlightHost(Platform::String ^ipAddress, Platform::String ^port) {
             this->ipAddress = ipAddress;
             this->port = port;
-            lastHostname = ipAddress + ":" + port;
+            this->hostname = port->IsEmpty() ? ipAddress : ipAddress + ":" + port;
             resolution = ref new ScreenResolution(1280, 720);
             loading = true;
         }
@@ -67,12 +67,12 @@ namespace moonlight_xbox_dx {
                 OnPropertyChanged("Port");
             }
         }
-        property Platform::String^ LastHostname
+        property Platform::String^ Hostname
         {
-            Platform::String^ get() { return this->lastHostname; }
-            void set(Platform::String^ value) {
-                this->lastHostname = value;
-                OnPropertyChanged("LastHostname");
+            Platform::String^ get() { return this->hostname; }
+            void set(Platform::String ^ value) { 
+                this->hostname = value;
+                OnPropertyChanged("Hostname");
             }
         }
 

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -240,6 +240,9 @@ static int load_serverinfo(PSERVER_DATA server, bool https) {
   if (xml_search(data->memory, data->size, "HttpsPort", &httpsPortText) != GS_OK)
     goto cleanup;
 
+  if (xml_search(data->memory, data->size, "mac", &server->macAddress) != GS_OK)
+      goto cleanup;
+
   if (xml_modelist(data->memory, data->size, &server->modes) != GS_OK)
     goto cleanup;
 
@@ -252,7 +255,7 @@ static int load_serverinfo(PSERVER_DATA server, bool https) {
   server->serverInfo.serverCodecModeSupport = serverCodecModeSupportText == NULL ? SCM_H264 : atoi(serverCodecModeSupportText);
   server->serverMajorVersion = atoi(server->serverInfo.serverInfoAppVersion);
   server->isNvidiaSoftware = strstr(stateText, "MJOLNIR") != NULL;
-
+ 
   server->httpsPort = atoi(httpsPortText);
   if (!server->httpsPort)
     server->httpsPort = 47984;

--- a/libgamestream/client.h
+++ b/libgamestream/client.h
@@ -42,6 +42,7 @@ typedef struct _SERVER_DATA {
   unsigned short httpsPort;
   char* serverName;
   char* uniqueId;
+  char* macAddress;
 } SERVER_DATA, *PSERVER_DATA;
 
 int gs_init(PSERVER_DATA server, char* address, unsigned short httpPort, const char *keyDirectory, int logLevel, bool unsupported);


### PR DESCRIPTION
Built off of the work of sixk32's PR.

Main changes:
- Separated IP Address and Port from mdnshandler
- Created further validation and dynamic handling for IP and broadcast addresses.

Notes:
- This version validates the given IP address. If it is the host name, it will retrieve the attached IP address. Tested by adding host by host name manually.
- Broadcast address is now configured dynamically.
- A lot of the work in the wake function can be broken down into smaller functions for cleaner code, but as these are single use, I decided it was unnecessary. Happy to clean things up and break it out if it helps though.

Happy to work on any changes you can see or answer any questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
 - Introduced a “Wake Host” option in the host selection interface, enabling users to quickly wake a host.  
 - Enhanced host setup now requires an IP address and port, improving connection accuracy.  
 - Added support for retrieving and displaying network details, including server MAC addresses, to improve connectivity insights.  
 - New dialog for adding hosts with structured input fields for IP address and port.  
- **Bug Fixes**  
 - Improved error messaging related to host connection failures.  
- **UI Enhancements**  
 - Updated displayed host information to reflect current hostname instead of last hostname across various settings and interfaces.  
<!-- end of auto-generated comment: release notes by coderabbit.ai -->