### PR TITLE
Wake On Lan (ServerAddress)

### DIFF
--- a/Pages/HostSelectorPage.xaml
+++ b/Pages/HostSelectorPage.xaml
@@ -12,6 +12,11 @@
     >
     <FlyoutBase.AttachedFlyout>
         <MenuFlyout x:Name="ActionsFlyout" AllowFocusOnInteraction="false" Placement="TopEdgeAlignedRight">
+            <MenuFlyoutItem x:Name="wakeHostButton" Click="wakeHostButton_Click" Text="Wake Host" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                <MenuFlyoutItem.Icon>
+                    <SymbolIcon Symbol="MapDrive" />
+                </MenuFlyoutItem.Icon>
+            </MenuFlyoutItem>
             <MenuFlyoutItem x:Name="hostSettingsButton" Click="hostSettingsButton_Click" Text="Host Settings" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
                 <MenuFlyoutItem.Icon>
                     <SymbolIcon Symbol="Setting" />

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -111,12 +111,10 @@ void moonlight_xbox_dx::HostSelectorPage::StartPairing(MoonlightHost^ host) {
 }
 
 
-
 void moonlight_xbox_dx::HostSelectorPage::removeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	State->RemoveHost(currentHost);
 }
-
 
 void moonlight_xbox_dx::HostSelectorPage::HostsGrid_RightTapped(Platform::Object^ sender, Windows::UI::Xaml::Input::RightTappedRoutedEventArgs^ e)
 {
@@ -140,7 +138,6 @@ void moonlight_xbox_dx::HostSelectorPage::hostSettingsButton_Click(Platform::Obj
 {
 	bool result = this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(HostSettingsPage::typeid), currentHost);
 }
-
 
 void moonlight_xbox_dx::HostSelectorPage::SettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
@@ -205,5 +202,31 @@ void moonlight_xbox_dx::HostSelectorPage::OnKeyDown(Platform::Object^ sender, Wi
 {
 	if (e->Key == Windows::System::VirtualKey::Enter) {
 		CoreInputView::GetForCurrentView()->TryHide();
+	}
+}
+
+void moonlight_xbox_dx::HostSelectorPage::wakeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	if (currentHost == nullptr) {
+		return;
+	}
+
+	try {
+		bool success = State->WakeHost(currentHost);
+
+		ContentDialog^ dialog = ref new ContentDialog();
+		dialog->Title = success ? "Wake Host" : "Wake Host Failed";
+		dialog->Content = success
+			? "Wake-on-LAN packet sent successfully to " + currentHost->ComputerName
+			: "Failed to send Wake-on-LAN packet.\n\nPlease check if Wake-on-LAN is enabled on the host.";
+		dialog->PrimaryButtonText = "OK";
+		dialog->ShowAsync();
+	}
+	catch (std::exception ex) {
+		ContentDialog^ dialog = ref new ContentDialog();
+		dialog->Title = "Wake Host Error";
+		dialog->Content = "An error occurred while trying to wake the host:\n\n" + Utils::StringFromChars((char*)ex.what());
+		dialog->PrimaryButtonText = "OK";
+		dialog->ShowAsync();
 	}
 }

--- a/Pages/HostSelectorPage.xaml.h
+++ b/Pages/HostSelectorPage.xaml.h
@@ -42,5 +42,6 @@ namespace moonlight_xbox_dx
 		void SettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		bool continueFetch = false;
 		void OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
+		void moonlight_xbox_dx::HostSelectorPage::wakeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -144,12 +144,12 @@ bool moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 		throw std::runtime_error("The client and host must be paired.");
 	}
 
-	if (host->MacAddress == nullptr || host->MacAddress == "00:00:00:00:00:00") {
+	if (host->MacAddress == nullptr || host->MacAddress->IsEmpty() || host->MacAddress == "00:00:00:00:00:00") {
 		Utils::Log("No recorded Mac address.\n");
 		throw std::runtime_error("No recorded Mac address.");
 	}
 
-	std::string& macAddress = Utils::PlatformStringToStdString(host->MacAddress);
+	std::string macAddress = Utils::PlatformStringToStdString(host->MacAddress);
 	std::string etherAddr;
 
 	for (size_t i = 0; i < macAddress.length();) {
@@ -158,7 +158,7 @@ bool moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 		for (size_t j = 0; j < macAddress.substr(i, 2).length(); ++j) {
 			hex <<= 4;
-			std::string& s = macAddress.substr(i, 2);
+			std::string s = macAddress.substr(i, 2);
 			if (isdigit(s[j])) {
 				hex |= s[j] - '0';
 			}
@@ -206,6 +206,7 @@ bool moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 
 	if (sendto(descriptor, message.c_str(), message.length(), 0,
 		reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
+		closesocket(descriptor);
 		return false;
 	}
 

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -351,8 +351,9 @@ std::pair<std::string, int> moonlight_xbox_dx::ApplicationState::Split_IP_Port(c
 	}
 }
 
-void moonlight_xbox_dx::ApplicationState::Throw_Error(char* message)
+void moonlight_xbox_dx::ApplicationState::Throw_Error(std::string message)
 {
-	Utils::Log(strcat(message, "\n"));
+	std::string msg = std::string() + message + "\n";
+	Utils::Log(msg.c_str());
 	throw std::runtime_error(message);
 }

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -2,8 +2,12 @@
 #include "ApplicationState.h"
 #include <Utils.hpp>
 #include <nlohmann/json.hpp>
+
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #include <WinSock2.h>
+#include <WS2tcpip.h>
+#include <sstream>
+#include <algorithm>
 
 using namespace Windows::Storage;
 Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
@@ -40,6 +44,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
 					if (a.contains("computername")) h->ComputerName = Utils::StringFromStdString(a["computername"].get<std::string>());
 					if (a.contains("playaudioonpc")) h->PlayAudioOnPC = a["playaudioonpc"].get<bool>();
 					if (a.contains("enable_hdr")) h->EnableHDR = a["enable_hdr"].get<bool>();
+					if (a.contains("serverAddress")) h->ServerAddress = Utils::StringFromStdString(a["serverAddress"].get<std::string>());
 					if (a.contains("macaddress")) h->MacAddress = Utils::StringFromStdString(a["macaddress"].get<std::string>());
 					else h->ComputerName = h->LastHostname;
 					this->SavedHosts->Append(h);
@@ -95,6 +100,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::UpdateFile()
 			hostJson["autoStartID"] = host->AutostartID;
 			hostJson["playaudioonpc"] = host->PlayAudioOnPC;
 			hostJson["enable_hdr"] = host->EnableHDR;
+			hostJson["serverAddress"] = Utils::PlatformStringToStdString(host->ServerAddress);
 
 			std::string macAddr = Utils::PlatformStringToStdString(host->MacAddress);
 			if (macAddr != "00:00:00:00:00:00" && macAddr != "")
@@ -139,34 +145,69 @@ moonlight_xbox_dx::ApplicationState^ moonlight_xbox_dx::GetApplicationState() {
 
 bool moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 {
+	Validate_WoL(host);
+	std::string wolPayload = WoL_Payload(Utils::PlatformStringToStdString(host->MacAddress));
+	int descriptor = Open_Socket();
+	auto addressList = Build_Unique_Addresses(host);
+
+	std::vector<int> ports = {
+		9, // Standard WOL port (privileged port)
+		47009, // Port opened by Moonlight Internet Hosting Tool for WoL (non-privileged port)
+		47998, 47999, 48000, 48002, 48010 // Ports opened by GFE
+	};
+
+	bool result = Send_Payload(descriptor, wolPayload, "255.255.255.255", 0);
+
+	for (int i = 0; i < addressList.size(); i++) {
+		for (int j = 0; j < ports.size(); j++) {
+			bool sendResult = Send_Payload(descriptor, wolPayload, addressList[i], ports[j]);
+
+			if (sendResult)
+			{
+				result = true;
+			}
+		}
+	}
+
+	closesocket(descriptor);
+	return result;
+}
+
+void moonlight_xbox_dx::ApplicationState::Validate_WoL(MoonlightHost^ host)
+{
 	if (host == nullptr || host->Connected)
 	{
-		Utils::Log("Host is already connected.\n");
-		throw std::runtime_error("Host is already connected.");
+		Throw_Error("Host is already connected.");
 	}
 
 	if (host->NotPaired) {
-		Utils::Log("The client and host must be paired.\n");
-		throw std::runtime_error("The client and host must be paired.");
+		Throw_Error("The client and host must be paired.");
+	}
+
+	if (!host->ServerAddress) {
+		Throw_Error("No recorded address was found");
 	}
 
 	if (host->MacAddress == nullptr || host->MacAddress->IsEmpty() || host->MacAddress == "00:00:00:00:00:00") {
-		Utils::Log("No recorded Mac address.\n");
-		throw std::runtime_error("No recorded Mac address.");
+		Throw_Error("No recorded Mac address.");
 	}
 
-	std::string macAddress = Utils::PlatformStringToStdString(host->MacAddress);
+	return;
+}
+
+std::string moonlight_xbox_dx::ApplicationState::WoL_Payload(std::string macAddress)
+{
 	std::string etherAddr;
 	std::string cleanMac;
 
 	for (char c : macAddress) {
 		if (isxdigit(c)) cleanMac += c;
 	}
-	
+
 	if (cleanMac.length() != 12) {
 		throw std::runtime_error(macAddress + " is not a valid ether address");
 	}
-	
+
 	for (size_t i = 0; i < 12; i += 2) {
 		char byte = static_cast<char>(std::stoi(cleanMac.substr(i, 2), nullptr, 16));
 		etherAddr += byte;
@@ -175,31 +216,143 @@ bool moonlight_xbox_dx::ApplicationState::WakeHost(MoonlightHost^ host)
 	if (etherAddr.length() != 6)
 		throw std::runtime_error(macAddress + " is not a valid ether address");
 
+	std::string payload(6, 0xFF);
+	for (size_t i = 0; i < 16; ++i) {
+		payload += etherAddr;
+	}
+
+	return payload;
+}
+
+int moonlight_xbox_dx::ApplicationState::Open_Socket()
+{
 	int descriptor = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (descriptor < 0)
-		throw std::runtime_error("Failed to open socket");
-
-	std::string message(6, 0xFF);
-	for (size_t i = 0; i < 16; ++i) {
-		message += etherAddr;
-	}
+		Throw_Error("Failed to open socket");
 
 	const int optval{ 1 };
-	if (setsockopt(descriptor, SOL_SOCKET, SO_BROADCAST, (char *) & optval, sizeof(optval)) < 0) {
-		throw std::runtime_error("Failed to set socket options");
+	if (setsockopt(descriptor, SOL_SOCKET, SO_BROADCAST, (char*)&optval, sizeof(optval)) < 0) {
+		Throw_Error("Failed to set socket options");
 	}
 
-	sockaddr_in addr{};
-	addr.sin_family = AF_INET;
-	addr.sin_addr.s_addr = 0xFFFFFFFF;
-	addr.sin_port = htons(60000);
+	return descriptor;
+}
 
-	if (sendto(descriptor, message.c_str(), message.length(), 0,
-		reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-		closesocket(descriptor);
+std::vector<std::string> moonlight_xbox_dx::ApplicationState::Build_Unique_Addresses(MoonlightHost^ host)
+{
+	std::vector<std::string> addresses;
+
+	if (host->ServerAddress)
+	{
+		addresses.push_back(Utils::PlatformStringToStdString(host->ServerAddress));
+	}
+
+	if (host->LastHostname)
+	{
+		auto hostnameSplit = Split_IP_Port(Utils::PlatformStringToStdString(host->LastHostname));
+		std::string hostIp = hostnameSplit.first;
+		addresses.push_back(hostIp);
+	}
+
+	if (inet_addr(Utils::PlatformStringToStdString(host->ServerAddress).c_str()) != -1)
+	{
+		std::string broadcastIP = Get_Broadcast_IP(Utils::PlatformStringToStdString(host->ServerAddress));
+		addresses.push_back(broadcastIP);
+	}
+
+	sort(addresses.begin(), addresses.end());
+	addresses.erase(unique(addresses.begin(), addresses.end()), addresses.end());
+
+	return addresses;
+}
+
+bool moonlight_xbox_dx::ApplicationState::Send_Payload(int descriptor, std::string payload, std::string address, int port)
+{
+	struct sockaddr_in addr;
+	memset(&addr, 0, sizeof(struct sockaddr_in));
+
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = inet_addr(address.c_str());
+	addr.sin_port = htons(port);
+
+	bind(descriptor, (struct sockaddr*)&addr, sizeof(addr));
+
+	int status = sendto(descriptor, payload.c_str(), (int)payload.length(), 0, (struct sockaddr*)&addr, sizeof(addr));
+	if (status == SOCKET_ERROR) {
+		std::string msg = std::string() + "Error sending Wake-On-Lan packet to " + address.c_str() + ":" + Utils::PlatformStringToStdString(port.ToString()) + "\n";
+		Utils::Log(msg.c_str());
 		return false;
 	}
 
-	closesocket(descriptor);
+	std::string msg = std::string() + "Wake-On-Lan packet sent to " + address.c_str() + ":" + Utils::PlatformStringToStdString(port.ToString()) + "\n";
+	Utils::Log(msg.c_str());
 	return true;
+}
+
+std::string moonlight_xbox_dx::ApplicationState::Get_Broadcast_IP(std::string ipAddress)
+{
+	// Get Subnet Mask
+	struct in_addr ip_addr;
+	if (inet_pton(AF_INET, ipAddress.c_str(), &ip_addr) != 1) {
+		WSACleanup();
+		Throw_Error("The given IP address was invalid.");
+	}
+
+	uint32_t ipAddress_int = ntohl(ip_addr.s_addr);
+	uint32_t subnetMask;
+
+	if ((ipAddress_int & 0xF0000000) == 0x00000000) { // Class A
+		subnetMask = 4278190080; // 255.0.0.0
+	}
+	else if ((ipAddress_int & 0xE0000000) == 0x80000000) { // Class B
+		subnetMask = 4294901760; // 255.255.0.0
+	}
+	else if ((ipAddress_int & 0xC0000000) == 0xC0000000) { // Class C
+		subnetMask = 4294967040; // 255.255.255.0
+	}
+	else {
+		Utils::Log("Could not determine subnet mask from IP address.\n");
+		WSACleanup();
+		throw std::runtime_error("Could not determine subnet mask from IP address.");
+	}
+
+	auto broadcastInt = ipAddress_int | (~subnetMask);
+
+	std::stringstream ss3;
+	for (int i = 3; i >= 0; --i) {
+		ss3 << ((broadcastInt >> (8 * i)) & 0xFF);
+		if (i > 0) {
+			ss3 << ".";
+		}
+	}
+	return ss3.str();
+}
+
+std::pair<std::string, int> moonlight_xbox_dx::ApplicationState::Split_IP_Port(const std::string& address)
+{
+	std::stringstream ss(address);
+	std::string ip_address;
+	std::string port_str;
+
+	if (std::getline(ss, ip_address, ':') && std::getline(ss, port_str)) {
+		try {
+			int port = std::stoi(port_str);
+			return { ip_address, port };
+		}
+		catch (const std::invalid_argument& e) {
+			throw std::invalid_argument("Invalid port number format");
+		}
+		catch (const std::out_of_range& e) {
+			throw std::out_of_range("Port number out of range");
+		}
+	}
+	else {
+		throw std::invalid_argument("Invalid address format");
+	}
+}
+
+void moonlight_xbox_dx::ApplicationState::Throw_Error(char* message)
+{
+	Utils::Log(strcat(message, "\n"));
+	throw std::runtime_error(message);
 }

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -23,6 +23,7 @@ namespace moonlight_xbox_dx {
 		std::string autostartInstance = "";
 		bool enableKeyboard = false;
 		bool shouldAutoConnect = false;
+		bool WakeHost(MoonlightHost^ host);
 		 
 	public:
 		//Thanks to https://phsucharee.wordpress.com/2013/06/19/data-binding-and-ccx-inotifypropertychanged/

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -32,7 +32,7 @@ namespace moonlight_xbox_dx {
 		bool Send_Payload(int descriptor, std::string payload, std::string address, int port);
 		std::string Get_Broadcast_IP(std::string ipAddress);
 		std::pair<std::string, int> Split_IP_Port(const std::string& address);
-		void Throw_Error(char* message);
+		void Throw_Error(std::string message);
 
 		 
 	public:

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -23,7 +23,17 @@ namespace moonlight_xbox_dx {
 		std::string autostartInstance = "";
 		bool enableKeyboard = false;
 		bool shouldAutoConnect = false;
+
 		bool WakeHost(MoonlightHost^ host);
+		void Validate_WoL(MoonlightHost^ host);
+		std::string WoL_Payload(std::string macAddress);
+		std::vector<std::string> Build_Unique_Addresses(MoonlightHost^ host);
+		int Open_Socket();
+		bool Send_Payload(int descriptor, std::string payload, std::string address, int port);
+		std::string Get_Broadcast_IP(std::string ipAddress);
+		std::pair<std::string, int> Split_IP_Port(const std::string& address);
+		void Throw_Error(char* message);
+
 		 
 	public:
 		//Thanks to https://phsucharee.wordpress.com/2013/06/19/data-binding-and-ccx-inotifypropertychanged/

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -361,10 +361,16 @@ Platform::String^ MoonlightClient::GetComputerName() {
 }
 
 Platform::String^ MoonlightClient::GetServerAddress() {
+	if (!serverData.serverInfo.address) {
+		return nullptr;
+	}
 	return Utils::StringFromChars((char*)serverData.serverInfo.address);
 }
 
 Platform::String^ MoonlightClient::GetServerMacAddress() {
+	if (!serverData.macAddress) {
+		return nullptr;
+	}
 	return Utils::StringFromChars(serverData.macAddress);
 }
 

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -360,6 +360,11 @@ Platform::String^ MoonlightClient::GetComputerName() {
 	return Utils::StringFromChars(serverData.serverName);
 }
 
+
+Platform::String^ MoonlightClient::GetServerMacAddress() {
+	return Utils::StringFromChars(serverData.macAddress);
+}
+
 void MoonlightClient::KeyDown(unsigned short v, char modifiers) {
 	LiSendKeyboardEvent2(v, KEY_ACTION_DOWN, modifiers, 0);
 }

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -360,6 +360,9 @@ Platform::String^ MoonlightClient::GetComputerName() {
 	return Utils::StringFromChars(serverData.serverName);
 }
 
+Platform::String^ MoonlightClient::GetServerAddress() {
+	return Utils::StringFromChars((char*)serverData.serverInfo.address);
+}
 
 Platform::String^ MoonlightClient::GetServerMacAddress() {
 	return Utils::StringFromChars(serverData.macAddress);

--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -38,6 +38,7 @@ namespace moonlight_xbox_dx {
 		void SendGuide(int controllerNumber, bool v);
 		Platform::String^ GetInstanceID();
 		Platform::String^ GetComputerName();
+		Platform::String^ GetServerAddress();
 		Platform::String^ GetServerMacAddress();
 		std::function<void(int)> OnStatusUpdate;
 		std::function<void()> OnCompleted;

--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -38,6 +38,7 @@ namespace moonlight_xbox_dx {
 		void SendGuide(int controllerNumber, bool v);
 		Platform::String^ GetInstanceID();
 		Platform::String^ GetComputerName();
+		Platform::String^ GetServerMacAddress();
 		std::function<void(int)> OnStatusUpdate;
 		std::function<void()> OnCompleted;
 		std::function<void(bool)> SetHDR;

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -12,7 +12,10 @@ namespace moonlight_xbox_dx {
 			this->Paired = client->IsPaired();
 			this->CurrentlyRunningAppId = client->GetRunningAppID();
 			this->InstanceId = client->GetInstanceID();
-			if (this->Connected) this->ComputerName = client->GetComputerName();
+			if (this->Connected) {
+				this->ComputerName = client->GetComputerName();
+				this->MacAddress = client->GetServerMacAddress();
+			}
 		}
 		this->Loading = false;
 	}

--- a/State/MoonlightHost.cpp
+++ b/State/MoonlightHost.cpp
@@ -14,6 +14,7 @@ namespace moonlight_xbox_dx {
 			this->InstanceId = client->GetInstanceID();
 			if (this->Connected) {
 				this->ComputerName = client->GetComputerName();
+				this->ServerAddress = client->GetServerAddress();
 				this->MacAddress = client->GetServerMacAddress();
 			}
 		}

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -11,6 +11,7 @@ namespace moonlight_xbox_dx {
         Platform::String^ instanceId;
         Platform::String^ lastHostname;
         Platform::String^ computerName;
+        Platform::String^ serverAddress;
         Platform::String^ macAddress;
         bool paired;
         bool connected;
@@ -62,6 +63,15 @@ namespace moonlight_xbox_dx {
             void set(Platform::String^ value) {
                 this->computerName = value;
                 OnPropertyChanged("ComputerName");
+            }
+        }
+
+        property Platform::String^ ServerAddress
+        {
+            Platform::String^ get() { return this->serverAddress; }
+            void set(Platform::String^ value) {
+                this->serverAddress = value;
+                OnPropertyChanged("ServerAddress");
             }
         }
 

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -11,6 +11,7 @@ namespace moonlight_xbox_dx {
         Platform::String^ instanceId;
         Platform::String^ lastHostname;
         Platform::String^ computerName;
+        Platform::String^ macAddress;
         bool paired;
         bool connected;
         bool loading = true;
@@ -61,6 +62,15 @@ namespace moonlight_xbox_dx {
             void set(Platform::String^ value) {
                 this->computerName = value;
                 OnPropertyChanged("ComputerName");
+            }
+        }
+
+        property Platform::String^ MacAddress
+        {
+            Platform::String^ get() { return this->macAddress; }
+            void set(Platform::String^ value) {
+                this->macAddress = value;
+                OnPropertyChanged("MacAddress");
             }
         }
 

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -240,6 +240,9 @@ static int load_serverinfo(PSERVER_DATA server, bool https) {
   if (xml_search(data->memory, data->size, "HttpsPort", &httpsPortText) != GS_OK)
     goto cleanup;
 
+  if (xml_search(data->memory, data->size, "mac", &server->macAddress) != GS_OK)
+      goto cleanup;
+
   if (xml_modelist(data->memory, data->size, &server->modes) != GS_OK)
     goto cleanup;
 

--- a/libgamestream/client.h
+++ b/libgamestream/client.h
@@ -42,6 +42,7 @@ typedef struct _SERVER_DATA {
   unsigned short httpsPort;
   char* serverName;
   char* uniqueId;
+  char* macAddress;
 } SERVER_DATA, *PSERVER_DATA;
 
 int gs_init(PSERVER_DATA server, char* address, unsigned short httpPort, const char *keyDirectory, int logLevel, bool unsupported);

--- a/libgamestream/client.h
+++ b/libgamestream/client.h
@@ -42,7 +42,7 @@ typedef struct _SERVER_DATA {
   unsigned short httpsPort;
   char* serverName;
   char* uniqueId;
-  char* macAddress;
+  char[18] macAddress;
 } SERVER_DATA, *PSERVER_DATA;
 
 int gs_init(PSERVER_DATA server, char* address, unsigned short httpPort, const char *keyDirectory, int logLevel, bool unsupported);

--- a/libgamestream/client.h
+++ b/libgamestream/client.h
@@ -42,7 +42,7 @@ typedef struct _SERVER_DATA {
   unsigned short httpsPort;
   char* serverName;
   char* uniqueId;
-  char[18] macAddress;
+  char* macAddress;
 } SERVER_DATA, *PSERVER_DATA;
 
 int gs_init(PSERVER_DATA server, char* address, unsigned short httpPort, const char *keyDirectory, int logLevel, bool unsupported);


### PR DESCRIPTION
Wake On Lan utilizing Mac Address and ServerAddress straight from the server data. I took some from the old PR as well and made a "best of both worlds". This will try to build from lastHostname, serverAddress, and broadcastIp to send out to all known ports for WoL.

Let me know how you feel about this one. It has been vastly cleaner and more stable than the previous version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a “Wake Host” button to the host selection menu, allowing users to remotely wake their host with immediate feedback on the operation.

- **Improvements**
  - Enhanced host connectivity details by including MAC address information.
  - Improved server data retrieval to ensure accurate host configuration display.
  - Introduced new properties for server address and MAC address in host management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->