### PR TITLE
Utils: improve string methods

### DIFF
--- a/Utils.cpp
+++ b/Utils.cpp
@@ -1,7 +1,14 @@
 #pragma once
 #include "pch.h"
 #include "Utils.hpp"
-#define LOG_LINES 64
+
+#include <locale>
+#include <codecvt>
+#include <string>
+#include <string_view>
+#include <array>
+
+constexpr auto LOG_LINES = 64;
 
 namespace moonlight_xbox_dx {
 	namespace Utils {
@@ -14,31 +21,33 @@ namespace moonlight_xbox_dx {
 		Platform::String^ StringPrintf(const char* fmt, ...) {
 			va_list list;
 			va_start(list, fmt);
-			char message[2048];
-			vsprintf_s(message, 2047, fmt, list);
-			std::string s_str = std::string(message);
-			std::wstring wid_str = std::wstring(s_str.begin(), s_str.end());
-			const wchar_t* w_char = wid_str.c_str();
-			Platform::String^ p_string = ref new Platform::String(w_char);
-			return p_string;
+			std::array<char, 2048> message{};
+			vsprintf_s(message.data(), message.size() - 1, fmt, list);
+			va_end(list);
+
+			return ref new Platform::String(NarrowToWideString(std::string_view(message.data())).c_str());
 		}
 
-		void Log(const char* fmt) {
+		void Log(const std::string_view& msg) {
 			try {
-				if (fmt == nullptr || fmt == NULL)return;
-				int len = strlen(fmt) + 1;
-				wchar_t* stringBuf = (wchar_t*)malloc(sizeof(wchar_t) * len);
-				if (stringBuf == NULL)return;
-				mbstowcs(stringBuf, fmt, len);
-				std::wstring string(stringBuf);
-				logMutex.lock();
-				if (logLines.size() == LOG_LINES)logLines.erase(logLines.begin());
-				logLines.push_back(string);
-				logMutex.unlock();
-				OutputDebugStringA(fmt);
+				std::wstring string = NarrowToWideString(msg);
+				{
+					std::unique_lock<std::mutex> lk(logMutex);
+					if (logLines.size() == LOG_LINES) {
+						logLines.erase(logLines.begin());
+					}
+					logLines.push_back(string);
+				}
+				OutputDebugString(string.c_str());
 			}
-			catch (...){
+			catch (...) {
 
+			}
+		}
+
+		void Log(const char* msg) {
+			if (msg) {
+				Log(std::string_view(msg));
 			}
 		}
 
@@ -46,30 +55,30 @@ namespace moonlight_xbox_dx {
 			return logLines;
 		}
 
-		//https://stackoverflow.com/a/20707518
-		Platform::String^ StringFromChars(char* chars)
+		Platform::String^ StringFromChars(const char* chars)
 		{
-			int wchars_num = MultiByteToWideChar(CP_UTF8, 0, chars, -1, NULL, 0);
-			wchar_t* wstr = new wchar_t[wchars_num];
-			MultiByteToWideChar(CP_UTF8, 0, chars, -1, wstr, wchars_num);
-			Platform::String^ str = ref new Platform::String(wstr);
-			delete[] wstr;
-			return str;
+			if (chars == nullptr) {
+				return nullptr;
+			}
+			return ref new Platform::String(NarrowToWideString(std::string_view(chars)).c_str());
 		}
 
-		//https://stackoverflow.com/a/43628199
 		Platform::String^ StringFromStdString(std::string input) {
-			std::wstring w_str = std::wstring(input.begin(), input.end());
-			const wchar_t* w_chars = w_str.c_str();
-			return (ref new Platform::String(w_chars));
+			return ref new Platform::String(NarrowToWideString(input).c_str());
 		}
 
-		//https://stackoverflow.com/a/35905753
 		std::string PlatformStringToStdString(Platform::String ^input) {
-			std::wstring fooW(input->Begin());
-			std::string fooA(fooW.begin(), fooW.end());
-			return fooA;
+			return WideToNarrowString(std::wstring(input->Begin()));
+		}
+
+		std::string WideToNarrowString(const std::wstring_view& str) {
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			return converter.to_bytes(str.data(), str.data() + str.size());
+		}
+
+		std::wstring NarrowToWideString(const std::string_view& str) {
+			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+			return converter.from_bytes(str.data(), str.data() + str.size());
 		}
 	}
-
 }

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -2,11 +2,9 @@
 #include "pch.h"
 #include "Utils.hpp"
 
-#include <locale>
-#include <codecvt>
 #include <string>
 #include <string_view>
-#include <array>
+#include <vector>
 
 constexpr auto LOG_LINES = 64;
 
@@ -84,13 +82,43 @@ namespace moonlight_xbox_dx {
 		}
 
 		std::string WideToNarrowString(const std::wstring_view& str) {
-			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-			return converter.to_bytes(str.data(), str.data() + str.size());
+			auto bufferSize = WideCharToMultiByte(CP_UTF8,
+				0,
+				str.data(),
+				str.length(),
+				nullptr,
+				0, nullptr, nullptr);
+
+			std::string result;
+			result.resize(bufferSize);
+			WideCharToMultiByte(CP_UTF8,
+				0,
+				str.data(),
+				str.length(),
+				result.data(),
+				result.size(), nullptr, nullptr);
+
+			return result;
 		}
 
 		std::wstring NarrowToWideString(const std::string_view& str) {
-			std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-			return converter.from_bytes(str.data(), str.data() + str.size());
+			auto bufferSize = MultiByteToWideChar(CP_UTF8,
+				0,
+				str.data(),
+				str.length(),
+				nullptr,
+				0);
+
+			std::wstring result;
+			result.resize(bufferSize);
+			MultiByteToWideChar(CP_UTF8,
+				0,
+				str.data(),
+				str.length(),
+				result.data(),
+				result.size());
+
+			return result;
 		}
 	}
 }

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -22,7 +22,7 @@ namespace moonlight_xbox_dx {
 
 			va_list args_copy;
 			va_copy(args_copy, args);
-			auto size = vsnprintf_s(nullptr, 0, 0, fmt, args_copy);
+			auto size = vsnprintf(nullptr, 0, fmt, args_copy);
 			va_end(args_copy);
 
 			if (size < 0) {

--- a/Utils.hpp
+++ b/Utils.hpp
@@ -26,12 +26,13 @@ namespace moonlight_xbox_dx {
 		
 		Platform::String^ StringPrintf(const char* fmt, ...);
 
-		void Log(const char* fmt);
+		void Log(const char* msg);
+		void Log(const std::string_view& msg);
 
 		std::vector<std::wstring> GetLogLines();
-		Platform::String^ StringFromChars(char* chars);
+		Platform::String^ StringFromChars(const char* chars);
 		Platform::String^ StringFromStdString(std::string st);
 		std::string PlatformStringToStdString(Platform::String^ input);
-
-	}
+		std::string WideToNarrowString(const std::wstring_view& str);
+		std::wstring NarrowToWideString(const std::string_view& str);	}
 }

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -149,7 +149,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -163,7 +164,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -177,7 +179,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -191,7 +194,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -205,7 +209,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -219,7 +224,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -233,7 +239,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)vcpkg_installed\x64-uwp\include;$(IntermediateOutputPath);third_party\moonlight-common-c\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -247,7 +254,8 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)vcpkg_installed\x64-uwp\include;$(IntermediateOutputPath);third_party\moonlight-common-c\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
This is a first of multiple PRs with fixes and some changes. I am cherry-picking changes from my [multiple-changes branch](https://github.com/LAGonauta/moonlight-xbox/tree/multiple-changes).

This PR:
1. Fix 2 KiB memory leak in the Log method
2. Adds Narrow to Wide and Wide to Narrow method using codecvt

Instead of fixing the current implementation, I am migrating to C++ RAII style. I find it is easier to reason about.
Additionally, I understand that codecvt got deprecated in C++17, and will be removed in C++... 26 I think. But its interface is so much easier to use than `MultiByteToWideChar` and `WideCharToMultiByte`. I can modify the code to those Windows APIs if you prefer, though.
I do not modify the other implementation files to properly use the new methods yet, but that PR will come if this is approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced flexible logging inputs and enhanced string conversion utilities for improved message handling.

- **Refactor**
  - Streamlined logging and conversion processes to boost reliability, efficiency, and exception safety.

- **Chores**
  - Updated build settings to adopt modern C++ standards across all configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->