### PR TITLE
Stop log spam about DEVICE_DRAW_SAMPLER_NOT_SET being logged every frame

### DIFF
--- a/Streaming/VideoRenderer.cpp
+++ b/Streaming/VideoRenderer.cpp
@@ -370,7 +370,8 @@ void VideoRenderer::CreateDeviceDependentResources()
 	samplerDesc.ComparisonFunc = D3D11_COMPARISON_NEVER;
 	samplerDesc.MinLOD = -FLT_MAX;
 	samplerDesc.MaxLOD = FLT_MAX;
-	DX::ThrowIfFailed(m_deviceResources->GetD3DDevice()->CreateSamplerState(&samplerDesc, samplerState.GetAddressOf()), "Sampler Creation");
+	DX::ThrowIfFailed(m_deviceResources->GetD3DDevice()->CreateSamplerState(&samplerDesc, &samplerState), "Sampler Creation");
+	m_deviceResources->GetD3DDeviceContext()->PSSetSamplers(0, 1, samplerState.GetAddressOf());
 	renderTextureDesc = { 0 };
 	int width = configuration->width;
 	int height = configuration->height;


### PR DESCRIPTION
This message is logged every frame and makes development using the log almost impossible. 

D3D11 WARNING: ID3D11DeviceContext::DrawIndexed: The Pixel Shader unit expects a Sampler to be set at Slot 0, but none is bound. This is perfectly valid, as a NULL Sampler maps to default Sampler state. However, the developer may not want to rely on the defaults.  [ EXECUTION WARNING #352: DEVICE_DRAW_SAMPLER_NOT_SET]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video rendering stability by refining how graphical resources are applied, resulting in more consistent playback and enhanced visual performance for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->