### PR TITLE
Wake on lan cidr

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
 
   <Identity
     Name="50497EliaZammuto.MoonlightUWP"
-    Publisher="CN=mpotr"
+	Publisher="CN=CE07B73A-712E-4E05-932B-D08CE2C8A87C"
     Version="1.16.3.0" />
 
   <mp:PhoneIdentity PhoneProductId="05850585-e2ce-441e-beae-1c76b89fe7ed" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
 
   <Identity
     Name="50497EliaZammuto.MoonlightUWP"
-    Publisher="CN=CE07B73A-712E-4E05-932B-D08CE2C8A87C"
+    Publisher="CN=mpotr"
     Version="1.16.3.0" />
 
   <mp:PhoneIdentity PhoneProductId="05850585-e2ce-441e-beae-1c76b89fe7ed" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -78,6 +78,12 @@ void moonlight_xbox_dx::HostSelectorPage::OnNewHostDialogPrimaryClick(Windows::U
 void moonlight_xbox_dx::HostSelectorPage::GridView_ItemClick(Platform::Object^ sender, Windows::UI::Xaml::Controls::ItemClickEventArgs^ e)
 {
 	MoonlightHost^ host = (MoonlightHost^)e->ClickedItem;
+
+	if (!host->Connected && host->Paired)
+	{
+		this->ActionsFlyout->ShowAt((FrameworkElement^)e->OriginalSource);
+	}
+
 	this->Connect(host);
 }
 

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -236,11 +236,11 @@ void moonlight_xbox_dx::ApplicationState::Validate_WoL(MoonlightHost^ host)
 	}
 
 	if (!host->ServerAddress) {
-		Throw_Error("No recorded address was found");
+		Throw_Error("No recorded address was found. Connect to host to resolve.");
 	}
 
 	if (host->MacAddress == nullptr || host->MacAddress->IsEmpty() || host->MacAddress == "00:00:00:00:00:00") {
-		Throw_Error("No recorded Mac address.");
+		Throw_Error("No recorded Mac address. Connect to host to resolve.");
 	}
 
 	return;
@@ -300,7 +300,7 @@ std::vector<std::string> moonlight_xbox_dx::ApplicationState::Build_Unique_Addre
 
 	if (host->LastHostname)
 	{
-		auto hostnameSplit = Split_IP_Port(Utils::PlatformStringToStdString(host->LastHostname));
+		auto hostnameSplit = Split_IP_Address(Utils::PlatformStringToStdString(host->LastHostname), ':');
 		std::string hostIp = hostnameSplit.first;
 		addresses.push_back(hostIp);
 	}
@@ -308,7 +308,10 @@ std::vector<std::string> moonlight_xbox_dx::ApplicationState::Build_Unique_Addre
 	if (inet_addr(Utils::PlatformStringToStdString(host->ServerAddress).c_str()) != -1)
 	{
 		std::string broadcastIP = Get_Broadcast_IP(Utils::PlatformStringToStdString(host->ServerAddress));
-		addresses.push_back(broadcastIP);
+		if (broadcastIP != "")
+		{
+			addresses.push_back(broadcastIP);
+		}
 	}
 
 	sort(addresses.begin(), addresses.end());
@@ -342,16 +345,29 @@ bool moonlight_xbox_dx::ApplicationState::Send_Payload(int descriptor, std::stri
 
 std::string moonlight_xbox_dx::ApplicationState::Get_Broadcast_IP(std::string ipAddress)
 {
-	// Get Subnet Mask
+	uint32_t subnetMask;
+	uint32_t ipAddress_int;
 	struct in_addr ip_addr;
-	if (inet_pton(AF_INET, ipAddress.c_str(), &ip_addr) != 1) {
-		WSACleanup();
-		Throw_Error("The given IP address was invalid.");
+
+	auto splitIP = Split_IP_Address(ipAddress, '/');
+	if (inet_pton(AF_INET, splitIP.first.c_str(), &ip_addr) != 1) {
+		throw std::invalid_argument("The given IP address was invalid.\n");
 	}
 
-	uint32_t ipAddress_int = ntohl(ip_addr.s_addr);
-	uint32_t subnetMask;
+	if (splitIP.second > 0)
+	{
+		struct sockaddr_in sa;
+		inet_pton(AF_INET, splitIP.first.c_str(), &(sa.sin_addr));
+		ipAddress_int = sa.sin_addr.s_addr;
+		uint32_t mask = htonl(~((1 << (32 - splitIP.second)) - 1));
+		uint32_t ip_num = ipAddress_int | ~mask;
+		sa.sin_addr.s_addr = ip_num;
+		char ip_stra[INET_ADDRSTRLEN];
+		inet_ntop(AF_INET, &(sa.sin_addr), ip_stra, INET_ADDRSTRLEN);
+		return std::string(ip_stra);
+	}
 
+	ipAddress_int = ntohl(ip_addr.s_addr);
 	if ((ipAddress_int & 0xF0000000) == 0x00000000) { // Class A
 		subnetMask = 4278190080; // 255.0.0.0
 	}
@@ -364,7 +380,7 @@ std::string moonlight_xbox_dx::ApplicationState::Get_Broadcast_IP(std::string ip
 	else {
 		Utils::Log("Could not determine subnet mask from IP address.\n");
 		WSACleanup();
-		throw std::runtime_error("Could not determine subnet mask from IP address.");
+		return "";
 	}
 
 	auto broadcastInt = ipAddress_int | (~subnetMask);
@@ -376,16 +392,18 @@ std::string moonlight_xbox_dx::ApplicationState::Get_Broadcast_IP(std::string ip
 			ss3 << ".";
 		}
 	}
+
 	return ss3.str();
 }
 
-std::pair<std::string, int> moonlight_xbox_dx::ApplicationState::Split_IP_Port(const std::string& address)
+std::pair<std::string, int> moonlight_xbox_dx::ApplicationState::Split_IP_Address(const std::string& address, char deliminator)
 {
 	std::stringstream ss(address);
 	std::string ip_address;
 	std::string port_str;
 
-	if (std::getline(ss, ip_address, ':') && std::getline(ss, port_str)) {
+	if (std::getline(ss, ip_address, deliminator) && std::getline(ss, port_str)) {
+
 		try {
 			int port = std::stoi(port_str);
 			return { ip_address, port };
@@ -398,7 +416,7 @@ std::pair<std::string, int> moonlight_xbox_dx::ApplicationState::Split_IP_Port(c
 		}
 	}
 	else {
-		throw std::invalid_argument("Invalid address format");
+		return { address, 0 };
 	}
 }
 

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -32,7 +32,7 @@ namespace moonlight_xbox_dx {
 		int Open_Socket();
 		bool Send_Payload(int descriptor, std::string payload, std::string address, int port);
 		std::string Get_Broadcast_IP(std::string ipAddress);
-		std::pair<std::string, int> Split_IP_Port(const std::string& address);
+		std::pair<std::string, int> Split_IP_Address(const std::string& address, char deliminator);
 		void Throw_Error(std::string message);
 
 		 

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -136,7 +136,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageDir>C:\Progetti\moonlight-xbox-dx\AppPackages\moonlight-xbox-dx\</AppxPackageDir>
-    <PackageCertificateThumbprint>760367B381EF6C36E6FC673B097F64C835208F54</PackageCertificateThumbprint>
+	<PackageCertificateKeyFile>moonlight-xbox-dx_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -136,7 +136,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageDir>C:\Progetti\moonlight-xbox-dx\AppPackages\moonlight-xbox-dx\</AppxPackageDir>
-    <PackageCertificateKeyFile>moonlight-xbox-dx_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateThumbprint>760367B381EF6C36E6FC673B097F64C835208F54</PackageCertificateThumbprint>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>


### PR DESCRIPTION
- Add support for cidr to WoL
- If host is paired, but not connected, show actions flyout. (currently does nothing, and other moonlight clients do this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the device selection interface so that context-specific options appear only for paired devices that aren’t yet connected.

- **Refactor**
  - Improved error messages to offer clearer guidance when connectivity issues occur.
  - Optimized network address handling to boost connection reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->