### PR TITLE
Use Loaded/Unloaded pair instead to unregister event

### DIFF
--- a/MoonlightWelcome.xaml.cpp
+++ b/MoonlightWelcome.xaml.cpp
@@ -24,12 +24,13 @@ using namespace Windows::UI::Xaml::Navigation;
 MoonlightWelcome::MoonlightWelcome()
 {
 	InitializeComponent();
-	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
-	navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &MoonlightWelcome::OnBackRequested);
 	Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->SetDesiredBoundsMode(Windows::UI::ViewManagement::ApplicationViewBoundsMode::UseVisible);
+
+	this->Loaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &MoonlightWelcome::OnLoaded);
+	this->Unloaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &MoonlightWelcome::OnUnloaded);
 }
 
-void moonlight_xbox_dx::MoonlightWelcome::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
+void MoonlightWelcome::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
 {
 	// UWP on Xbox One triggers a back request whenever the B
 	// button is pressed which can result in the app being
@@ -44,29 +45,26 @@ void moonlight_xbox_dx::MoonlightWelcome::OnBackRequested(Platform::Object^ e, W
 		args->Handled = true;
 		return;
 	}
-
 }
 
-
-void moonlight_xbox_dx::MoonlightWelcome::GoForward(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void MoonlightWelcome::GoForward(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->FlipView->SelectedIndex = this->FlipView->SelectedIndex + 1;
 }
 
-void moonlight_xbox_dx::MoonlightWelcome::GoBack(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void MoonlightWelcome::GoBack(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->FlipView->SelectedIndex = this->FlipView->SelectedIndex - 1;
 }
 
-void moonlight_xbox_dx::MoonlightWelcome::CloseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void MoonlightWelcome::CloseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	GetApplicationState()->FirstTime = false;
 	GetApplicationState()->UpdateFile();
 	this->Frame->GoBack();
 }
 
-
-void moonlight_xbox_dx::MoonlightWelcome::Page_KeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
+void MoonlightWelcome::Page_KeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
 {
 	if (e->OriginalKey != Windows::System::VirtualKey::GamepadA)return;
 	if (this->FlipView->Items->Size == (this->FlipView->SelectedIndex + 1)) {
@@ -77,4 +75,16 @@ void moonlight_xbox_dx::MoonlightWelcome::Page_KeyDown(Platform::Object^ sender,
 	else {
 		this->FlipView->SelectedIndex = this->FlipView->SelectedIndex + 1;
 	}
+}
+
+void MoonlightWelcome::OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &MoonlightWelcome::OnBackRequested);
+}
+
+void MoonlightWelcome::OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	navigation->BackRequested -= m_back_token;
 }

--- a/MoonlightWelcome.xaml.h
+++ b/MoonlightWelcome.xaml.h
@@ -15,6 +15,8 @@ namespace moonlight_xbox_dx
 	[Windows::Foundation::Metadata::WebHostHidden]
 	public ref class MoonlightWelcome sealed
 	{
+	private:
+		Windows::Foundation::EventRegistrationToken m_back_token;
 	public:
 		MoonlightWelcome();
 	private:
@@ -23,5 +25,7 @@ namespace moonlight_xbox_dx
 		void CloseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void Page_KeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
 		void OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args);
+		void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }

--- a/Pages/AppPage.xaml.cpp
+++ b/Pages/AppPage.xaml.cpp
@@ -8,6 +8,7 @@
 #include "State\MoonlightClient.h"
 #include "StreamPage.xaml.h"
 #include "HostSettingsPage.xaml.h"
+#include "Utils.hpp"
 
 using namespace moonlight_xbox_dx;
 
@@ -27,15 +28,18 @@ using namespace Windows::UI::Xaml::Navigation;
 
 AppPage::AppPage()
 {
-	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
-	navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &AppPage::OnBackRequested);
 	InitializeComponent();
 	Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->SetDesiredBoundsMode(Windows::UI::ViewManagement::ApplicationViewBoundsMode::UseVisible);
+
+	this->Loaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &AppPage::OnLoaded);
+	this->Unloaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &AppPage::OnUnloaded);
 }
 
 void AppPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ e) {
 	MoonlightHost^ mhost = dynamic_cast<MoonlightHost^>(e->Parameter);
-	if (mhost == nullptr)return;
+	if (mhost == nullptr) {
+		return;
+	}
 	host = mhost;
 	host->UpdateStats();
 	host->UpdateApps();
@@ -49,9 +53,7 @@ void AppPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ 
 	GetApplicationState()->shouldAutoConnect = false;
 }
 
-
-
-void moonlight_xbox_dx::AppPage::AppsGrid_ItemClick(Platform::Object^ sender, Windows::UI::Xaml::Controls::ItemClickEventArgs^ e)
+void AppPage::AppsGrid_ItemClick(Platform::Object^ sender, Windows::UI::Xaml::Controls::ItemClickEventArgs^ e)
 {
 	MoonlightApp^ app = (MoonlightApp^)e->ClickedItem;
 	this->Connect(app->Id);
@@ -76,7 +78,7 @@ void AppPage::Connect(int appId) {
 }
 
 
-void moonlight_xbox_dx::AppPage::HostsGrid_RightTapped(Platform::Object^ sender, Windows::UI::Xaml::Input::RightTappedRoutedEventArgs^ e)
+void AppPage::HostsGrid_RightTapped(Platform::Object^ sender, Windows::UI::Xaml::Input::RightTappedRoutedEventArgs^ e)
 {
 	FrameworkElement^ senderElement = (FrameworkElement^)e->OriginalSource;
 	currentApp = (MoonlightApp^)senderElement->DataContext;
@@ -84,39 +86,54 @@ void moonlight_xbox_dx::AppPage::HostsGrid_RightTapped(Platform::Object^ sender,
 }
 
 
-void moonlight_xbox_dx::AppPage::resumeAppButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void AppPage::resumeAppButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->Connect(this->currentApp->Id);
 }
 
 
-void moonlight_xbox_dx::AppPage::closeAppButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void AppPage::closeAppButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
-	auto client = new MoonlightClient();
-	char ipAddressStr[2048];
-	wcstombs_s(NULL, ipAddressStr, Host->LastHostname->Data(), 2047);
-	int status = client->Connect(ipAddressStr);
-	if (status == 0)client->StopApp();
+	MoonlightClient client;
+	auto ipAddr = Utils::PlatformStringToStdString(Host->LastHostname);
+	int status = client.Connect(ipAddr.c_str());
+	if (status == 0) {
+		client.StopApp();
+	}
 	host->UpdateStats();
 }
 
 
-void moonlight_xbox_dx::AppPage::backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void AppPage::backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->Frame->GoBack();
 }
 
 
-void moonlight_xbox_dx::AppPage::settingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void AppPage::settingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	bool result = this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(HostSettingsPage::typeid), Host);
 }
 
-void moonlight_xbox_dx::AppPage::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
+void AppPage::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
 {
 	// UWP on Xbox One triggers a back request whenever the B
 	// button is pressed which can result in the app being
 	// suspended if unhandled
-	this->Frame->GoBack();
-	args->Handled = true;
+	if (this->Frame->CanGoBack) {
+		this->Frame->GoBack();
+		args->Handled = true;
+	}
+}
+
+void AppPage::OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	m_back_cookie = navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &AppPage::OnBackRequested);
+}
+
+void AppPage::OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	navigation->BackRequested -= m_back_cookie;
 }

--- a/Pages/AppPage.xaml.h
+++ b/Pages/AppPage.xaml.h
@@ -19,6 +19,7 @@ namespace moonlight_xbox_dx
 	private:
 		MoonlightHost^ host;
 		MoonlightApp^ currentApp;
+		Windows::Foundation::EventRegistrationToken m_back_cookie;
 	protected:
 		virtual void OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ e) override;
  		void Connect(int app);
@@ -37,5 +38,7 @@ namespace moonlight_xbox_dx
 		void closeAppButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void settingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -36,12 +36,11 @@ HostSelectorPage::HostSelectorPage()
 	InitializeComponent();
 }
 
-
-void moonlight_xbox_dx::HostSelectorPage::NewHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void HostSelectorPage::NewHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	dialogHostnameTextBox = ref new TextBox();
 	dialogHostnameTextBox->AcceptsReturn = false;
-	dialogHostnameTextBox->KeyDown += ref new Windows::UI::Xaml::Input::KeyEventHandler(this, &moonlight_xbox_dx::HostSelectorPage::OnKeyDown);
+	dialogHostnameTextBox->KeyDown += ref new Windows::UI::Xaml::Input::KeyEventHandler(this, &HostSelectorPage::OnKeyDown);
 	ContentDialog^ dialog = ref new ContentDialog();
 	dialog->Content = dialogHostnameTextBox;
 	dialog->Title = L"Add new Host";
@@ -49,11 +48,10 @@ void moonlight_xbox_dx::HostSelectorPage::NewHostButton_Click(Platform::Object^ 
 	dialog->PrimaryButtonText = "Ok";
 	dialog->SecondaryButtonText = "Cancel";
 	dialog->ShowAsync();
-	dialog->PrimaryButtonClick += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Xaml::Controls::ContentDialog^, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^>(this, &moonlight_xbox_dx::HostSelectorPage::OnNewHostDialogPrimaryClick);
+	dialog->PrimaryButtonClick += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Xaml::Controls::ContentDialog^, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^>(this, &HostSelectorPage::OnNewHostDialogPrimaryClick);
 }
 
-
-void moonlight_xbox_dx::HostSelectorPage::OnNewHostDialogPrimaryClick(Windows::UI::Xaml::Controls::ContentDialog^ sender, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^ args)
+void HostSelectorPage::OnNewHostDialogPrimaryClick(Windows::UI::Xaml::Controls::ContentDialog^ sender, Windows::UI::Xaml::Controls::ContentDialogButtonClickEventArgs^ args)
 {
 	sender->IsPrimaryButtonEnabled = false;
 	Platform::String^ hostname = dialogHostnameTextBox->Text;
@@ -74,14 +72,13 @@ void moonlight_xbox_dx::HostSelectorPage::OnNewHostDialogPrimaryClick(Windows::U
 		});
 }
 
-
-void moonlight_xbox_dx::HostSelectorPage::GridView_ItemClick(Platform::Object^ sender, Windows::UI::Xaml::Controls::ItemClickEventArgs^ e)
+void HostSelectorPage::GridView_ItemClick(Platform::Object^ sender, Windows::UI::Xaml::Controls::ItemClickEventArgs^ e)
 {
 	MoonlightHost^ host = (MoonlightHost^)e->ClickedItem;
 	this->Connect(host);
 }
 
-void moonlight_xbox_dx::HostSelectorPage::StartPairing(MoonlightHost^ host) {
+void HostSelectorPage::StartPairing(MoonlightHost^ host) {
 	MoonlightClient* client = new MoonlightClient();
 	char ipAddressStr[2048];
 	wcstombs_s(NULL, ipAddressStr, host->LastHostname->Data(), 2047);
@@ -107,16 +104,15 @@ void moonlight_xbox_dx::HostSelectorPage::StartPairing(MoonlightHost^ host) {
 				host->UpdateStats();
 			}
 		));
-		});
+	});
 }
 
-
-void moonlight_xbox_dx::HostSelectorPage::removeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void HostSelectorPage::removeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	State->RemoveHost(currentHost);
 }
 
-void moonlight_xbox_dx::HostSelectorPage::HostsGrid_RightTapped(Platform::Object^ sender, Windows::UI::Xaml::Input::RightTappedRoutedEventArgs^ e)
+void HostSelectorPage::HostsGrid_RightTapped(Platform::Object^ sender, Windows::UI::Xaml::Input::RightTappedRoutedEventArgs^ e)
 {
 	//Thanks to https://stackoverflow.com/questions/62878368/uwp-gridview-listview-get-the-righttapped-item-supporting-both-mouse-and-xbox-co
 	FrameworkElement^ senderElement = (FrameworkElement^)e->OriginalSource;
@@ -134,17 +130,17 @@ void moonlight_xbox_dx::HostSelectorPage::HostsGrid_RightTapped(Platform::Object
 	this->ActionsFlyout->ShowAt(senderElement);
 }
 
-void moonlight_xbox_dx::HostSelectorPage::hostSettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void HostSelectorPage::hostSettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	bool result = this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(HostSettingsPage::typeid), currentHost);
 }
 
-void moonlight_xbox_dx::HostSelectorPage::SettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void HostSelectorPage::SettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	bool result = this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(MoonlightSettings::typeid));
 }
 
-void moonlight_xbox_dx::HostSelectorPage::OnStateLoaded() {
+void HostSelectorPage::OnStateLoaded() {
 	if (GetApplicationState()->FirstTime) {
 		this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(MoonlightWelcome::typeid));
 		return;
@@ -171,7 +167,7 @@ void moonlight_xbox_dx::HostSelectorPage::OnStateLoaded() {
 
 }
 
-void moonlight_xbox_dx::HostSelectorPage::Connect(MoonlightHost^ host) {
+void HostSelectorPage::Connect(MoonlightHost^ host) {
 	if (!host->Connected)return;
 	if (!host->Paired) {
 		StartPairing(host);
@@ -181,7 +177,6 @@ void moonlight_xbox_dx::HostSelectorPage::Connect(MoonlightHost^ host) {
 	continueFetch = false;
 	bool result = this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(AppPage::typeid), host);
 }
-
 
 void HostSelectorPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ e) {
 	Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->SetDesiredBoundsMode(Windows::UI::ViewManagement::ApplicationViewBoundsMode::UseVisible);
@@ -198,7 +193,7 @@ void HostSelectorPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEv
 		});
 }
 
-void moonlight_xbox_dx::HostSelectorPage::OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
+void HostSelectorPage::OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
 {
 	if (e->Key == Windows::System::VirtualKey::Enter) {
 		CoreInputView::GetForCurrentView()->TryHide();

--- a/Pages/HostSettingsPage.xaml.cpp
+++ b/Pages/HostSettingsPage.xaml.cpp
@@ -27,10 +27,11 @@ using namespace Windows::UI::ViewManagement::Core;
 
 HostSettingsPage::HostSettingsPage()
 {
-	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
-	navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &HostSettingsPage::OnBackRequested);
 	InitializeComponent();
 	Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->SetDesiredBoundsMode(Windows::UI::ViewManagement::ApplicationViewBoundsMode::UseVisible);
+
+	this->Loaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &HostSettingsPage::OnLoaded);
+	this->Unloaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &HostSettingsPage::OnUnloaded);
 }
 
 static bool SortModes(HdmiDisplayMode^ a, HdmiDisplayMode^ b) {
@@ -141,13 +142,13 @@ void HostSettingsPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEv
 	}
 }
 
-void moonlight_xbox_dx::HostSettingsPage::backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void HostSettingsPage::backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	GetApplicationState()->UpdateFile();
 	this->Frame->GoBack();
 }
 
-void moonlight_xbox_dx::HostSettingsPage::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
+void HostSettingsPage::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
 {
 	// UWP on Xbox One triggers a back request whenever the B
 	// button is pressed which can result in the app being
@@ -157,13 +158,13 @@ void moonlight_xbox_dx::HostSettingsPage::OnBackRequested(Platform::Object^ e, W
 	args->Handled = true;
 }
 
-void moonlight_xbox_dx::HostSettingsPage::StreamResolutionSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
+void HostSettingsPage::StreamResolutionSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
 {
 	CurrentStreamResolutionIndex = this->StreamResolutionSelector->SelectedIndex;
 	host->StreamResolution = AvailableStreamResolutions->GetAt(CurrentStreamResolutionIndex);
 }
 
-void moonlight_xbox_dx::HostSettingsPage::DisplayResolutionSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
+void HostSettingsPage::DisplayResolutionSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
 {
 	CurrentDisplayResolutionIndex = this->DisplayResolutionSelector->SelectedIndex;
 	host->HdmiDisplayMode = FilterMode();
@@ -172,19 +173,19 @@ void moonlight_xbox_dx::HostSettingsPage::DisplayResolutionSelector_SelectionCha
 	OnPropertyChanged("CurrentFPSIndex");
 }
 
-void moonlight_xbox_dx::HostSettingsPage::FPSSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
+void HostSettingsPage::FPSSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
 {
 	CurrentFPSIndex = this->FPSComboBox->SelectedIndex >= 0 ? this->FPSComboBox->SelectedIndex : UpdateFPSIndex(AvailableFPS, host->HdmiDisplayMode->HdmiDisplayMode->RefreshRate);;
 	host->HdmiDisplayMode = FilterMode();
 	HDRAvailable = IsHDRAvailable();
 }
 
-void moonlight_xbox_dx::HostSettingsPage::EnableHDR_Checked(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
+void HostSettingsPage::EnableHDR_Checked(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
 {
 	host->HdmiDisplayMode = FilterMode();
 }
 
-void moonlight_xbox_dx::HostSettingsPage::AutoStartSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
+void HostSettingsPage::AutoStartSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
 {
 	int index = AutoStartSelector->SelectedIndex - 1;
 	if (index >= 0 && host->Apps->Size > index) {
@@ -195,19 +196,19 @@ void moonlight_xbox_dx::HostSettingsPage::AutoStartSelector_SelectionChanged(Pla
 	}
 }
 
-void moonlight_xbox_dx::HostSettingsPage::GlobalSettingsOption_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void HostSettingsPage::GlobalSettingsOption_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(MoonlightSettings::typeid));
 }
 
-void moonlight_xbox_dx::HostSettingsPage::BitrateInput_KeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
+void HostSettingsPage::BitrateInput_KeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e)
 {
 	if (e->Key == Windows::System::VirtualKey::Enter) {
 		CoreInputView::GetForCurrentView()->TryHide();
 	}
 }
 
-HdmiDisplayModeWrapper^ moonlight_xbox_dx::HostSettingsPage::FilterMode()
+HdmiDisplayModeWrapper^ HostSettingsPage::FilterMode()
 {
 	HdmiDisplayModeWrapper^ mode;
 	bool hdrAvailable = false;
@@ -284,7 +285,7 @@ HdmiDisplayModeWrapper^ moonlight_xbox_dx::HostSettingsPage::FilterMode()
 	return mode;
 }
 
-Platform::Collections::Vector<double>^ moonlight_xbox_dx::HostSettingsPage::UpdateFPS()
+Platform::Collections::Vector<double>^ HostSettingsPage::UpdateFPS()
 {
 	auto availableFPS = ref new Platform::Collections::Vector<double>();
 	auto selectedResolution = AvailableDisplayResolutions->GetAt(currentDisplayResolutionIndex);
@@ -317,7 +318,7 @@ Platform::Collections::Vector<double>^ moonlight_xbox_dx::HostSettingsPage::Upda
 	return availableFPS;
 }
 
-bool moonlight_xbox_dx::HostSettingsPage::IsHDRAvailable()
+bool HostSettingsPage::IsHDRAvailable()
 {
 	bool isAvailable = false;
 	for (int i = 0; i < availableModes->Size; i++)
@@ -339,9 +340,21 @@ bool moonlight_xbox_dx::HostSettingsPage::IsHDRAvailable()
 	return isAvailable;
 }
 
-void moonlight_xbox_dx::HostSettingsPage::OnPropertyChanged(Platform::String^ propertyName)
+void HostSettingsPage::OnPropertyChanged(Platform::String^ propertyName)
 {
 	Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([this, propertyName]() {
 		PropertyChanged(this, ref new  Windows::UI::Xaml::Data::PropertyChangedEventArgs(propertyName));
 		}));
+}
+
+void HostSettingsPage::OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	m_back_cookie = navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &HostSettingsPage::OnBackRequested);
+}
+
+void HostSettingsPage::OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	navigation->BackRequested -= m_back_cookie;
 }

--- a/Pages/HostSettingsPage.xaml.h
+++ b/Pages/HostSettingsPage.xaml.h
@@ -31,6 +31,7 @@ namespace moonlight_xbox_dx
 		int currentDisplayResolutionIndex = 0;
 		int currentFPSIndex = 0;
 		int currentAppIndex = 0;
+		Windows::Foundation::EventRegistrationToken m_back_cookie;
 	protected:
 		virtual void OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ e) override;
 	public:
@@ -173,5 +174,7 @@ namespace moonlight_xbox_dx
 		HdmiDisplayModeWrapper^ FilterMode();
 		Platform::Collections::Vector<double>^ UpdateFPS();
 		bool IsHDRAvailable();
+		void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }

--- a/Pages/MoonlightSettings.xaml.cpp
+++ b/Pages/MoonlightSettings.xaml.cpp
@@ -29,8 +29,6 @@ MoonlightSettings::MoonlightSettings()
 {
 	InitializeComponent();
 	state = GetApplicationState();
-	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
-	navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &MoonlightSettings::OnBackRequested);
 	auto item = ref new ComboBoxItem();
 	item->Content = "Don't autoconnect";
 	item->DataContext = "";
@@ -60,17 +58,17 @@ MoonlightSettings::MoonlightSettings()
 		}
 		k++;
 	}
+	this->Loaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &MoonlightSettings::OnLoaded);
+	this->Unloaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &MoonlightSettings::OnUnloaded);
 }
 
-
-void moonlight_xbox_dx::MoonlightSettings::backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void MoonlightSettings::backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	GetApplicationState()->UpdateFile();
 	this->Frame->GoBack();
 }
 
-
-void moonlight_xbox_dx::MoonlightSettings::HostSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
+void MoonlightSettings::HostSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
 {
 	ComboBoxItem^ item = (ComboBoxItem^)this->HostSelector->SelectedItem;
 
@@ -79,7 +77,7 @@ void moonlight_xbox_dx::MoonlightSettings::HostSelector_SelectionChanged(Platfor
 
 }
 
-void moonlight_xbox_dx::MoonlightSettings::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
+void MoonlightSettings::OnBackRequested(Platform::Object^ e, Windows::UI::Core::BackRequestedEventArgs^ args)
 {
 	// UWP on Xbox One triggers a back request whenever the B
 	// button is pressed which can result in the app being
@@ -90,16 +88,28 @@ void moonlight_xbox_dx::MoonlightSettings::OnBackRequested(Platform::Object^ e, 
 
 }
 
-void moonlight_xbox_dx::MoonlightSettings::WelcomeButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void MoonlightSettings::WelcomeButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(MoonlightWelcome::typeid));
 }
 
-
-void moonlight_xbox_dx::MoonlightSettings::LayoutSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
+void MoonlightSettings::LayoutSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)
 {
 	ComboBoxItem^ item = (ComboBoxItem^)this->KeyboardLayoutSelector->SelectedItem;
 
 	auto s = item->DataContext->ToString();
 	state->KeyboardLayout = s;
+}
+
+void MoonlightSettings::OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	m_back_cookie = navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &MoonlightSettings::OnBackRequested);
+}
+
+
+void MoonlightSettings::OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	navigation->BackRequested -= m_back_cookie;
 }

--- a/Pages/MoonlightSettings.xaml.h
+++ b/Pages/MoonlightSettings.xaml.h
@@ -17,6 +17,7 @@ namespace moonlight_xbox_dx
 	{
 	private: 
 		ApplicationState^ state;
+		Windows::Foundation::EventRegistrationToken m_back_cookie;
 	public:
 		MoonlightSettings();
 		property ApplicationState^ State {
@@ -31,5 +32,7 @@ namespace moonlight_xbox_dx
 		void HostSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e);
 		void WelcomeButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void LayoutSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e);
+		void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }

--- a/Pages/StreamPage.xaml.cpp
+++ b/Pages/StreamPage.xaml.cpp
@@ -30,8 +30,6 @@ StreamPage::StreamPage():
 	m_windowVisible(true),
 	m_coreInput(nullptr)
 {
-	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
-	navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &StreamPage::OnBackRequested);
 	InitializeComponent();
 
 	DisplayInformation^ currentDisplayInformation = DisplayInformation::GetForCurrentView();
@@ -40,6 +38,9 @@ StreamPage::StreamPage():
 		ref new SizeChangedEventHandler(this, &StreamPage::OnSwapChainPanelSizeChanged);
 	m_deviceResources = std::make_shared<DX::DeviceResources>();
 	//Resize to make fullscreen on Xbox
+
+	this->Loaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &StreamPage::OnLoaded);
+	this->Unloaded += ref new Windows::UI::Xaml::RoutedEventHandler(this, &StreamPage::OnUnloaded);
 }
 
 
@@ -60,8 +61,8 @@ void StreamPage::Page_Loaded(Platform::Object^ sender, Windows::UI::Xaml::Routed
 {
 	try {
 		Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->SetDesiredBoundsMode(Windows::UI::ViewManagement::ApplicationViewBoundsMode::UseCoreWindow);
-		keyDownHandler = (Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow^, Windows::UI::Core::KeyEventArgs^>(this, &moonlight_xbox_dx::StreamPage::OnKeyDown));
-		keyUpHandler = (Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyUp += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow^, Windows::UI::Core::KeyEventArgs^>(this, &moonlight_xbox_dx::StreamPage::OnKeyUp));
+		keyDownHandler = (Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow^, Windows::UI::Core::KeyEventArgs^>(this, &StreamPage::OnKeyDown));
+		keyUpHandler = (Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyUp += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow^, Windows::UI::Core::KeyEventArgs^>(this, &StreamPage::OnKeyUp));
 		// At this point we have access to the device. 
 		// We can create the device-dependent resources.
 		m_deviceResources->SetSwapChainPanel(swapChainPanel);
@@ -109,27 +110,27 @@ void StreamPage::OnSwapChainPanelSizeChanged(Object^ sender, Windows::UI::Xaml::
 }
 
 
-void moonlight_xbox_dx::StreamPage::flyoutButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::flyoutButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	Windows::UI::Xaml::Controls::Flyout::ShowAttachedFlyout((FrameworkElement^)sender);
 	m_main->SetFlyoutOpened(true);
 }
 
 
-void moonlight_xbox_dx::StreamPage::ActionsFlyout_Closed(Platform::Object^ sender, Platform::Object^ e)
+void StreamPage::ActionsFlyout_Closed(Platform::Object^ sender, Platform::Object^ e)
 {
 	if(m_main != nullptr) m_main->SetFlyoutOpened(false);
 }
 
 
-void moonlight_xbox_dx::StreamPage::toggleMouseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::toggleMouseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	m_main->mouseMode = !m_main->mouseMode;
 	this->toggleMouseButton->Text = m_main->mouseMode ? "Exit Mouse Mode" : "Toggle Mouse Mode";
 }
 
 
-void moonlight_xbox_dx::StreamPage::toggleLogsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::toggleLogsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	Utils::showLogs = !Utils::showLogs;
 	this->toggleLogsButton->Text = Utils::showLogs ? "Hide Logs" : "Show Logs";
@@ -141,14 +142,14 @@ void StreamPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArg
 	if (configuration == nullptr)return;
 }
 
-void moonlight_xbox_dx::StreamPage::toggleStatsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::toggleStatsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	Utils::showStats = !Utils::showStats;
 	this->toggleStatsButton->Text = Utils::showStats ? "Hide Stats" : "Show Stats";
 }
 
 
-void moonlight_xbox_dx::StreamPage::disonnectButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::disonnectButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown -= keyDownHandler;
 	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyUp -= keyUpHandler;
@@ -157,7 +158,7 @@ void moonlight_xbox_dx::StreamPage::disonnectButton_Click(Platform::Object^ send
 	this->Frame->GoBack();
 }
 
-void moonlight_xbox_dx::StreamPage::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ e)
+void StreamPage::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ e)
 {
 	//Ignore Gamepad input
 	if (e->VirtualKey >= Windows::System::VirtualKey::GamepadA && e->VirtualKey <= Windows::System::VirtualKey::GamepadRightThumbstickLeft) {
@@ -171,7 +172,7 @@ void moonlight_xbox_dx::StreamPage::OnKeyDown(Windows::UI::Core::CoreWindow^ sen
 }
 
 
-void moonlight_xbox_dx::StreamPage::OnKeyUp(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ e)
+void StreamPage::OnKeyUp(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Core::KeyEventArgs^ e)
 {
 	//Ignore Gamepad input
 	if (e->VirtualKey >= Windows::System::VirtualKey::GamepadA && e->VirtualKey <= Windows::System::VirtualKey::GamepadRightThumbstickLeft) {
@@ -186,7 +187,7 @@ void moonlight_xbox_dx::StreamPage::OnKeyUp(Windows::UI::Core::CoreWindow^ sende
 }
 
 
-void moonlight_xbox_dx::StreamPage::disconnectAndCloseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::disconnectAndCloseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown -= keyDownHandler;
 	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyUp -= keyUpHandler;	
@@ -196,25 +197,39 @@ void moonlight_xbox_dx::StreamPage::disconnectAndCloseButton_Click(Platform::Obj
 	this->Frame->GoBack();
 }
 
-void moonlight_xbox_dx::StreamPage::Keyboard_OnKeyDown(moonlight_xbox_dx::KeyboardControl^ sender, moonlight_xbox_dx::KeyEvent^ e)
+void StreamPage::Keyboard_OnKeyDown(KeyboardControl^ sender, KeyEvent^ e)
 {
 	this->m_main->OnKeyDown(e->VirtualKey, e->Modifiers);
 }
 
 
-void moonlight_xbox_dx::StreamPage::Keyboard_OnKeyUp(moonlight_xbox_dx::KeyboardControl^ sender, moonlight_xbox_dx::KeyEvent^ e)
+void StreamPage::Keyboard_OnKeyUp(KeyboardControl^ sender, KeyEvent^ e)
 {
 	this->m_main->OnKeyUp(e->VirtualKey, e->Modifiers);
 }
 
 
-void moonlight_xbox_dx::StreamPage::guideButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::guideButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->m_main->SendGuideButton(500);
 }
 
 
-void moonlight_xbox_dx::StreamPage::guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void StreamPage::guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->m_main->SendGuideButton(3000);
+}
+
+
+void StreamPage::OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	m_back_cookie = navigation->BackRequested += ref new EventHandler<BackRequestedEventArgs^>(this, &StreamPage::OnBackRequested);
+}
+
+
+void StreamPage::OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+	navigation->BackRequested -= m_back_cookie;
 }

--- a/Pages/StreamPage.xaml.h
+++ b/Pages/StreamPage.xaml.h
@@ -73,6 +73,7 @@ namespace moonlight_xbox_dx
 		// Track our independent input on a background worker thread.
 		Windows::Foundation::IAsyncAction^ m_inputLoopWorker;
 		Windows::UI::Core::CoreIndependentInputSource^ m_coreInput;
+		Windows::Foundation::EventRegistrationToken m_back_cookie;
 
 		// Resources used to render the DirectX content in the XAML page background.
 		std::shared_ptr<DX::DeviceResources> m_deviceResources;
@@ -95,6 +96,8 @@ namespace moonlight_xbox_dx
 		void Keyboard_OnKeyUp(moonlight_xbox_dx::KeyboardControl^ sender, moonlight_xbox_dx::KeyEvent^ e);
 		void guideButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 	};
 }
 


### PR DESCRIPTION
While debugging the debugger indicated the app was emitting multiple Disconnected exceptions. I don't know if this translates into crashes in the app, but it is certainly annoying and shouldn't be happening.

My formatter also automatically removed some extra `moonlight_xbox_dx::` from method names. If that is not something desired I can revert those changes.

This is a continuation of the my cherry-picking changes from my [multiple-changes branch](https://github.com/LAGonauta/moonlight-xbox/tree/multiple-changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced navigation responsiveness and page transitions for a smoother user experience.
  - Streamlined how pages handle their loading and unloading, ensuring consistent behavior (e.g., for back navigation) across the app.

These updates improve overall stability and reliability during navigation without altering visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->