### PR TITLE
Add support for clientRefreshRateX100, enabling streaming at 59.94 or 119.88 hz

### DIFF
--- a/Common/DeviceResources.cpp
+++ b/Common/DeviceResources.cpp
@@ -75,6 +75,8 @@ DX::DeviceResources::DeviceResources() :
 	m_deviceNotify(nullptr),
 	m_stats(nullptr)
 {
+	m_refreshRate = GetUWPRefreshRate();
+
 	CreateDeviceIndependentResources();
 	CreateDeviceResources();
 }
@@ -816,4 +818,22 @@ void DX::DeviceResources::GetUWPPixelDimensions(uint32_t *width, uint32_t *heigh
 		*width  = CoreWindow::GetForCurrentThread()->Bounds.Width * surface_scale;
 		*height = CoreWindow::GetForCurrentThread()->Bounds.Height * surface_scale;
 	}
+}
+
+double DX::DeviceResources::GetUWPRefreshRate()
+{
+	GAMING_DEVICE_MODEL_INFORMATION info = {};
+	GetGamingDeviceModelInformation(&info);
+
+	double refreshRate = 0.0f;
+
+	if (info.vendorId == GAMING_DEVICE_VENDOR_ID_MICROSOFT) {
+		// Running on Xbox
+		refreshRate = HdmiDisplayInformation::GetForCurrentView()->GetCurrentDisplayMode()->RefreshRate;
+	}
+	else {
+		// It seems difficult to get the refresh rate in Windows, TODO
+	}
+
+	return refreshRate;
 }

--- a/Common/DeviceResources.h
+++ b/Common/DeviceResources.h
@@ -28,11 +28,13 @@ namespace DX
 		void GetDXGIFrameStatistics(std::shared_ptr<moonlight_xbox_dx::Stats>& dstStats);
 		void Present();
 		void GetUWPPixelDimensions(uint32_t *width, uint32_t *height);
+		double GetUWPRefreshRate();
 		void SetForceTearing(bool forceTearing);
 		static int uwp_get_width();
 		static int uwp_get_height();
 
 		void                       SetEnableVsync(bool ev)                  { m_enableVsync = ev; }
+		double                     GetRefreshRate() const                   { return m_refreshRate; }
 
 		// Stats helpers
 		void                        SetStats(const std::shared_ptr<moonlight_xbox_dx::Stats>& stats)  { m_stats = stats; }
@@ -91,6 +93,7 @@ namespace DX
 		float											m_compositionScaleX;
 		float											m_compositionScaleY;
 		DWORD                                           m_dxgiFactoryFlags;
+		double                                          m_refreshRate;
 
 		// Variables that take into account whether the app supports high resolution screens or not.
 		float											m_effectiveDpi;

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -218,7 +218,11 @@ int MoonlightClient::StartStreaming(std::shared_ptr<DX::DeviceResources> res, St
 	config.width = sConfig->width;
 	config.height = sConfig->height;
 	config.bitrate = sConfig->bitrate;
-	config.clientRefreshRateX100 = sConfig->FPS * 100;
+	if (res->GetRefreshRate() > 0.0) {
+		// request stream matching our exact fractional refresh rate
+		config.clientRefreshRateX100 = (int)(res->GetRefreshRate() * 100.0);
+		Utils::Logf("Requesting stream with clientRefreshRateX100=%d for %.2f\n", config.clientRefreshRateX100, res->GetRefreshRate());
+	}
 	config.colorRange = this->IsRGBFull() ? COLOR_RANGE_FULL : COLOR_RANGE_LIMITED;
 	config.colorSpace = COLORSPACE_REC_601;
 	config.encryptionFlags = 0;


### PR DESCRIPTION
I've submitted a Sunshine PR [1] to support an old unused GFE parameter for fractional refresh rates. The easiest client that could test this is Xbox and the patch is very small. You can verify that it's working in the Sunshine log by looking for a line like this: `Info: Requested frame rate [60000/1001 exactly 59.94 fps]`

I've also modified dregu's frameskip tool [2] to support fractional rates. Whether or not it's accurate enough to matter, I don't know, but it's better than nothing. Xbox still needs better frame pacing which I'm working on, but this may be a small improvement in the meantime. I have tested this at 119.88 and 59.94.

[1] https://github.com/LizardByte/Sunshine/pull/4019
[2] https://andygrundman.github.io/frameskip/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now detects and uses the display's refresh rate on Xbox devices, improving streaming configuration accuracy.
  * Added logging to indicate the detected and requested refresh rate during streaming startup.

* **Bug Fixes**
  * Streaming refresh rate is now set only when a valid refresh rate is available from the device, preventing incorrect configurations on unsupported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->