### PR TITLE
Add ImGui-based graphs to stats display. Add network jitter (pacing) drop stat.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,30 @@
+BasedOnStyle: LLVM
+UseTab: ForIndentation
+IndentWidth: 4
+TabWidth: 4
+BreakBeforeBraces: Mozilla
+ColumnLimit: 0
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+IndentCaseLabels: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignTrailingComments: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BreakConstructorInitializers: AfterColon
+
+# Don't move pch.h below other headers
+IncludeBlocks: Preserve
+IncludeCategories:
+  # PCH must be first
+  - Regex: '^"pch\.h"$'
+    Priority: 1
+
+  # system headers (<...>)
+  - Regex: '^<.*>'
+    Priority: 2
+
+  # everything else
+  - Regex: '.*'
+    Priority: 3

--- a/.gitignore
+++ b/.gitignore
@@ -346,4 +346,5 @@ vcpkg_installed
 
 # Syncthing
 .stfolder/
+.stignore
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/DirectXTK"]
 	path = third_party/DirectXTK
 	url = https://github.com/microsoft/DirectXTK.git
+[submodule "third_party/imgui"]
+	path = third_party/imgui
+	url = https://github.com/ocornut/imgui.git

--- a/Common/DeviceResources.h
+++ b/Common/DeviceResources.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "../State/Stats.h"
+#include <windows.ui.xaml.media.dxinterop.h>
 
 namespace DX
 {
@@ -25,7 +26,6 @@ namespace DX
 		void HandleDeviceLost();
 		void RegisterDeviceNotify(IDeviceNotify* deviceNotify);
 		void Trim();
-		void GetDXGIFrameStatistics(std::shared_ptr<moonlight_xbox_dx::Stats>& dstStats);
 		void Present();
 		void GetUWPPixelDimensions(uint32_t *width, uint32_t *height);
 		double GetUWPRefreshRate();
@@ -33,8 +33,15 @@ namespace DX
 		static int uwp_get_width();
 		static int uwp_get_height();
 
-		void                       SetEnableVsync(bool ev)                  { m_enableVsync = ev; }
-		double                     GetRefreshRate() const                   { return m_refreshRate; }
+		bool                        GetEnableVsync() const                  { return m_enableVsync; }
+		void                        SetEnableVsync(bool ev)                 { m_enableVsync = ev; }
+		double                      GetRefreshRate() const                  { return m_refreshRate; }
+		void                        SetRefreshRate(double rate)             { m_refreshRate = rate; }
+		double                      GetFrameRate() const                    { return m_frameRate; }
+		void                        SetFrameRate(double rate)               { m_frameRate = rate; }
+
+		bool                        GetShowImGui() const                    { return m_showImGui; }
+		void                        SetShowImGui(bool show)                 { m_showImGui = show; }
 
 		// Stats helpers
 		void                        SetStats(const std::shared_ptr<moonlight_xbox_dx::Stats>& stats)  { m_stats = stats; }
@@ -68,6 +75,9 @@ namespace DX
 		void UpdateRenderTargetSize();
 		DXGI_MODE_ROTATION ComputeDisplayRotation();
 
+		void ImGui_Init(const Microsoft::WRL::ComPtr<ISwapChainPanelNative>& panelNative, float dpi);
+		void ImGui_Deinit();
+
 		// Direct3D objects.
 		Microsoft::WRL::ComPtr<IDXGIFactory2>           m_dxgiFactory;
 		Microsoft::WRL::ComPtr<ID3D11Device3>			m_d3dDevice;
@@ -94,6 +104,7 @@ namespace DX
 		float											m_compositionScaleY;
 		DWORD                                           m_dxgiFactoryFlags;
 		double                                          m_refreshRate;
+		double                                          m_frameRate;
 
 		// Variables that take into account whether the app supports high resolution screens or not.
 		float											m_effectiveDpi;
@@ -111,7 +122,9 @@ namespace DX
 		bool                                            m_enableVsync;
 		bool                                            m_swapchainVsync;
 		bool                                            m_forceTearing;
+		bool                                            m_showImGui;
 		SyncMode                                        m_displayStatus;
 		std::shared_ptr<moonlight_xbox_dx::Stats>       m_stats;
+		bool                                            m_imguiRunning;
 	};
 }

--- a/Common/imconfig.moonlight.h
+++ b/Common/imconfig.moonlight.h
@@ -1,0 +1,144 @@
+//-----------------------------------------------------------------------------
+// DEAR IMGUI COMPILE-TIME OPTIONS
+// Runtime options (clipboard callbacks, enabling various features, etc.) can generally be set via the ImGuiIO structure.
+// You can use ImGui::SetAllocatorFunctions() before calling ImGui::CreateContext() to rewire memory allocation functions.
+//-----------------------------------------------------------------------------
+// A) You may edit imconfig.h (and not overwrite it when updating Dear ImGui, or maintain a patch/rebased branch with your modifications to it)
+// B) or '#define IMGUI_USER_CONFIG "my_imgui_config.h"' in your project and then add directives in your own file without touching this template.
+//-----------------------------------------------------------------------------
+// You need to make sure that configuration settings are defined consistently _everywhere_ Dear ImGui is used, which include the imgui*.cpp
+// files but also _any_ of your code that uses Dear ImGui. This is because some compile-time options have an affect on data structures.
+// Defining those options in imconfig.h will ensure every compilation unit gets to see the same data structure layouts.
+// Call IMGUI_CHECKVERSION() from your .cpp file to verify that the data structures your files are using are matching the ones imgui.cpp is using.
+//-----------------------------------------------------------------------------
+
+#pragma once
+
+// Gamepad events can crash UWP backend
+#define IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+
+//---- Define assertion handler. Defaults to calling assert().
+// If your macro uses multiple statements, make sure is enclosed in a 'do { .. } while (0)' block so it can be used as a single statement.
+//#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
+//#define IM_ASSERT(_EXPR)  ((void)(_EXPR))     // Disable asserts
+
+//---- Define attributes of all API symbols declarations, e.g. for DLL under Windows
+// Using Dear ImGui via a shared library is not recommended, because of function call overhead and because we don't guarantee backward nor forward ABI compatibility.
+// - Windows DLL users: heaps and globals are not shared across DLL boundaries! You will need to call SetCurrentContext() + SetAllocatorFunctions()
+//   for each static/DLL boundary you are calling from. Read "Context and Memory Allocators" section of imgui.cpp for more details.
+//#define IMGUI_API __declspec(dllexport)                   // MSVC Windows: DLL export
+//#define IMGUI_API __declspec(dllimport)                   // MSVC Windows: DLL import
+//#define IMGUI_API __attribute__((visibility("default")))  // GCC/Clang: override visibility when set is hidden
+
+//---- Don't define obsolete functions/enums/behaviors. Consider enabling from time to time after updating to clean your code of obsolete function/names.
+//#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+
+//---- Disable all of Dear ImGui or don't implement standard windows/tools.
+// It is very strongly recommended to NOT disable the demo windows and debug tool during development. They are extremely useful in day to day work. Please read comments in imgui_demo.cpp.
+//#define IMGUI_DISABLE                                     // Disable everything: all headers and source files will be empty.
+//#define IMGUI_DISABLE_DEMO_WINDOWS                        // Disable demo windows: ShowDemoWindow()/ShowStyleEditor() will be empty.
+//#define IMGUI_DISABLE_DEBUG_TOOLS                         // Disable metrics/debugger and other debug tools: ShowMetricsWindow(), ShowDebugLogWindow() and ShowIDStackToolWindow() will be empty.
+
+//---- Don't implement some functions to reduce linkage requirements.
+#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc. (user32.lib/.a, kernel32.lib/.a)
+//#define IMGUI_ENABLE_WIN32_DEFAULT_IME_FUNCTIONS          // [Win32] [Default with Visual Studio] Implement default IME handler (require imm32.lib/.a, auto-link for Visual Studio, -limm32 on command-line for MinGW)
+//#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS         // [Win32] [Default with non-Visual Studio compilers] Don't implement default IME handler (won't require imm32.lib/.a)
+//#define IMGUI_DISABLE_WIN32_FUNCTIONS                     // [Win32] Won't use and link with any Win32 function (clipboard, IME).
+//#define IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS      // [OSX] Implement default OSX clipboard handler (need to link with '-framework ApplicationServices', this is why this is not the default).
+//#define IMGUI_DISABLE_DEFAULT_SHELL_FUNCTIONS             // Don't implement default platform_io.Platform_OpenInShellFn() handler (Win32: ShellExecute(), require shell32.lib/.a, Mac/Linux: use system("")).
+//#define IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS            // Don't implement ImFormatString/ImFormatStringV so you can implement them yourself (e.g. if you don't want to link with vsnprintf)
+//#define IMGUI_DISABLE_DEFAULT_MATH_FUNCTIONS              // Don't implement ImFabs/ImSqrt/ImPow/ImFmod/ImCos/ImSin/ImAcos/ImAtan2 so you can implement them yourself.
+//#define IMGUI_DISABLE_FILE_FUNCTIONS                      // Don't implement ImFileOpen/ImFileClose/ImFileRead/ImFileWrite and ImFileHandle at all (replace them with dummies)
+//#define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS              // Don't implement ImFileOpen/ImFileClose/ImFileRead/ImFileWrite and ImFileHandle so you can implement them yourself if you don't want to link with fopen/fclose/fread/fwrite. This will also disable the LogToTTY() function.
+//#define IMGUI_DISABLE_DEFAULT_ALLOCATORS                  // Don't implement default allocators calling malloc()/free() to avoid linking with them. You will need to call ImGui::SetAllocatorFunctions().
+//#define IMGUI_DISABLE_DEFAULT_FONT                        // Disable default embedded font (ProggyClean.ttf), remove ~9.5 KB from output binary. AddFontDefault() will assert.
+//#define IMGUI_DISABLE_SSE                                 // Disable use of SSE intrinsics even if available
+
+//---- Enable Test Engine / Automation features.
+//#define IMGUI_ENABLE_TEST_ENGINE                          // Enable imgui_test_engine hooks. Generally set automatically by include "imgui_te_config.h", see Test Engine for details.
+
+//---- Include imgui_user.h at the end of imgui.h as a convenience
+// May be convenient for some users to only explicitly include vanilla imgui.h and have extra stuff included.
+//#define IMGUI_INCLUDE_IMGUI_USER_H
+//#define IMGUI_USER_H_FILENAME         "my_folder/my_imgui_user.h"
+
+//---- Pack vertex colors as BGRA8 instead of RGBA8 (to avoid converting from one to another). Need dedicated backend support.
+//#define IMGUI_USE_BGRA_PACKED_COLOR
+
+//---- Use legacy CRC32-adler tables (used before 1.91.6), in order to preserve old .ini data that you cannot afford to invalidate.
+//#define IMGUI_USE_LEGACY_CRC32_ADLER
+
+//---- Use 32-bit for ImWchar (default is 16-bit) to support Unicode planes 1-16. (e.g. point beyond 0xFFFF like emoticons, dingbats, symbols, shapes, ancient languages, etc...)
+//#define IMGUI_USE_WCHAR32
+
+//---- Avoid multiple STB libraries implementations, or redefine path/filenames to prioritize another version
+// By default the embedded implementations are declared static and not available outside of Dear ImGui sources files.
+//#define IMGUI_STB_TRUETYPE_FILENAME   "my_folder/stb_truetype.h"
+//#define IMGUI_STB_RECT_PACK_FILENAME  "my_folder/stb_rect_pack.h"
+//#define IMGUI_STB_SPRINTF_FILENAME    "my_folder/stb_sprintf.h"    // only used if IMGUI_USE_STB_SPRINTF is defined.
+//#define IMGUI_DISABLE_STB_TRUETYPE_IMPLEMENTATION
+//#define IMGUI_DISABLE_STB_RECT_PACK_IMPLEMENTATION
+//#define IMGUI_DISABLE_STB_SPRINTF_IMPLEMENTATION                   // only disabled if IMGUI_USE_STB_SPRINTF is defined.
+
+//---- Use stb_sprintf.h for a faster implementation of vsnprintf instead of the one from libc (unless IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS is defined)
+// Compatibility checks of arguments and formats done by clang and GCC will be disabled in order to support the extra formats provided by stb_sprintf.h.
+//#define IMGUI_USE_STB_SPRINTF
+
+//---- Use FreeType to build and rasterize the font atlas (instead of stb_truetype which is embedded by default in Dear ImGui)
+// Requires FreeType headers to be available in the include path. Requires program to be compiled with 'misc/freetype/imgui_freetype.cpp' (in this repository) + the FreeType library (not provided).
+// On Windows you may use vcpkg with 'vcpkg install freetype --triplet=x64-windows' + 'vcpkg integrate install'.
+//#define IMGUI_ENABLE_FREETYPE
+
+//---- Use FreeType + plutosvg or lunasvg to render OpenType SVG fonts (SVGinOT)
+// Only works in combination with IMGUI_ENABLE_FREETYPE.
+// - plutosvg is currently easier to install, as e.g. it is part of vcpkg. It will support more fonts and may load them faster. See misc/freetype/README for instructions.
+// - Both require headers to be available in the include path + program to be linked with the library code (not provided).
+// - (note: lunasvg implementation is based on Freetype's rsvg-port.c which is licensed under CeCILL-C Free Software License Agreement)
+//#define IMGUI_ENABLE_FREETYPE_PLUTOSVG
+//#define IMGUI_ENABLE_FREETYPE_LUNASVG
+
+//---- Use stb_truetype to build and rasterize the font atlas (default)
+// The only purpose of this define is if you want force compilation of the stb_truetype backend ALONG with the FreeType backend.
+//#define IMGUI_ENABLE_STB_TRUETYPE
+
+//---- Define constructor and implicit cast operators to convert back<>forth between your math types and ImVec2/ImVec4.
+// This will be inlined as part of ImVec2 and ImVec4 class declarations.
+/*
+#define IM_VEC2_CLASS_EXTRA                                                     \
+        constexpr ImVec2(const MyVec2& f) : x(f.x), y(f.y) {}                   \
+        operator MyVec2() const { return MyVec2(x,y); }
+
+#define IM_VEC4_CLASS_EXTRA                                                     \
+        constexpr ImVec4(const MyVec4& f) : x(f.x), y(f.y), z(f.z), w(f.w) {}   \
+        operator MyVec4() const { return MyVec4(x,y,z,w); }
+*/
+//---- ...Or use Dear ImGui's own very basic math operators.
+//#define IMGUI_DEFINE_MATH_OPERATORS
+
+//---- Use 32-bit vertex indices (default is 16-bit) is one way to allow large meshes with more than 64K vertices.
+// Your renderer backend will need to support it (most example renderer backends support both 16/32-bit indices).
+// Another way to allow large meshes while keeping 16-bit indices is to handle ImDrawCmd::VtxOffset in your renderer.
+// Read about ImGuiBackendFlags_RendererHasVtxOffset for details.
+//#define ImDrawIdx unsigned int
+
+//---- Override ImDrawCallback signature (will need to modify renderer backends accordingly)
+//struct ImDrawList;
+//struct ImDrawCmd;
+//typedef void (*MyImDrawCallback)(const ImDrawList* draw_list, const ImDrawCmd* cmd, void* my_renderer_user_data);
+//#define ImDrawCallback MyImDrawCallback
+
+//---- Debug Tools: Macro to break in Debugger (we provide a default implementation of this in the codebase)
+// (use 'Metrics->Tools->Item Picker' to pick widgets with the mouse and break into them for easy debugging.)
+//#define IM_DEBUG_BREAK  IM_ASSERT(0)
+//#define IM_DEBUG_BREAK  __debugbreak()
+
+//---- Debug Tools: Enable slower asserts
+//#define IMGUI_DEBUG_PARANOID
+
+//---- Tip: You can add extra functions within the ImGui:: namespace from anywhere (e.g. your own sources/header files)
+/*
+namespace ImGui
+{
+    void MyFunction(const char* name, MyMatrix44* mtx);
+}
+*/

--- a/Pages/HostSettingsPage.xaml
+++ b/Pages/HostSettingsPage.xaml
@@ -55,7 +55,7 @@
             <TextBlock Grid.Row="1" Grid.Column="0">FPS</TextBlock>
             <ComboBox ItemsSource="{x:Bind AvailableFPS}" SelectedItem="{x:Bind Host.FPS,Mode=TwoWay}" Grid.Row="1"  Grid.Column="1"></ComboBox>
             <TextBlock Grid.Row="2" Grid.Column="0">Bitrate</TextBlock>
-            <Slider Grid.Row="2" Grid.Column="1" Value="{x:Bind Host.Bitrate}" x:DefaultBindMode="TwoWay" Minimum="5000" Maximum="300000" SmallChange="500" TickFrequency="10000" StepFrequency="1000" />
+            <Slider Grid.Row="2" Grid.Column="1" Value="{x:Bind Host.Bitrate}" x:DefaultBindMode="TwoWay" Minimum="5000" Maximum="500000" SmallChange="10000" TickFrequency="50000" StepFrequency="50000" />
             <TextBlock Grid.Row="3" Grid.Column="0">Audio Configuration</TextBlock>
             <ComboBox ItemsSource="{x:Bind AvailableAudioConfigs}" SelectedItem="{x:Bind Host.AudioConfig,Mode=TwoWay}"  Grid.Row="3"  Grid.Column="1"></ComboBox>
             <TextBlock Grid.Row="4" Grid.Column="0">Play Audio on Host PC</TextBlock>

--- a/Pages/StreamPage.xaml
+++ b/Pages/StreamPage.xaml
@@ -47,14 +47,14 @@
                         </MenuFlyoutItem>
                     </MenuFlyoutSubItem>
                     <MenuFlyoutSeparator></MenuFlyoutSeparator>
+                    <MenuFlyoutItem x:Name="toggleStatsButton" Text="Show Stats &amp; Graphs" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" Click="toggleStatsButton_Click">
+                        <MenuFlyoutItem.Icon>
+                            <FontIcon Glyph="&#xEC48;" />
+                        </MenuFlyoutItem.Icon>
+                    </MenuFlyoutItem>
                     <MenuFlyoutItem x:Name="toggleLogsButton" Text="Show Logs" AllowFocusOnInteraction="false" Click="toggleLogsButton_Click"  FocusVisualSecondaryThickness="0.5" >
                         <MenuFlyoutItem.Icon>
                             <FontIcon Glyph="&#xF0B5;" />
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutItem x:Name="toggleStatsButton" Text="Show Stats" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" Click="toggleStatsButton_Click">
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xEC48;" />
                         </MenuFlyoutItem.Icon>
                     </MenuFlyoutItem>
                     <MenuFlyoutSeparator></MenuFlyoutSeparator>

--- a/Plot/ImGuiPlots.cpp
+++ b/Plot/ImGuiPlots.cpp
@@ -1,0 +1,43 @@
+// clang-format off
+#include "pch.h"
+// clang-format on
+#include "ImGuiPlots.h"
+#include <cassert>
+#include <numeric>
+#include <vector>
+#include "PlotDesc.h"
+
+Plot::Plot(const PlotDesc &d, std::size_t capacity) :
+    desc(d), buffer(capacity) {}
+
+// singleton
+ImGuiPlots &ImGuiPlots::instance()
+{
+	static ImGuiPlots s;
+	return s;
+}
+
+ImGuiPlots::ImGuiPlots() :
+    plots_{{
+        Plot(kPlotDescs[PLOT_FRAMETIME]),
+        Plot(kPlotDescs[PLOT_HOST_FRAMETIME]),
+        Plot(kPlotDescs[PLOT_QUEUED_FRAMES]),
+        Plot(kPlotDescs[PLOT_DROPPED_NETWORK]),
+        Plot(kPlotDescs[PLOT_DROPPED_PACER]),
+    }}
+{
+}
+
+ImGuiPlots::~ImGuiPlots() = default;
+
+void ImGuiPlots::clearData()
+{
+	for (auto &p : plots_)
+		p.buffer.clear();
+}
+
+void ImGuiPlots::observeFloat(int plotId, float value)
+{
+	assert(plotId >= 0 && plotId < PlotCount);
+	plots_[static_cast<std::size_t>(plotId)].buffer.push(static_cast<float>(value));
+}

--- a/Plot/ImGuiPlots.h
+++ b/Plot/ImGuiPlots.h
@@ -1,0 +1,45 @@
+#pragma once
+#include "../Utils/FloatBuffer.h"
+#include "PlotDesc.h"
+#include <array>
+
+struct Plot
+{
+	const PlotDesc &desc; // non-owning reference to metadata
+	FloatBuffer buffer;   // runtime samples
+
+	explicit Plot(const PlotDesc &d, std::size_t capacity = 512);
+};
+
+class ImGuiPlots
+{
+  public:
+	static ImGuiPlots &instance();
+
+	void clearData();
+	void observeFloat(int plotId, float value);
+
+	Plot &get(int plotId)
+	{
+		return plots_[static_cast<std::size_t>(plotId)];
+	}
+	const Plot &get(int plotId) const
+	{
+		return plots_[static_cast<std::size_t>(plotId)];
+	}
+
+	std::array<Plot, PlotCount> &plots()
+	{
+		return plots_;
+	}
+	const std::array<Plot, PlotCount> &plots() const
+	{
+		return plots_;
+	}
+
+  private:
+	ImGuiPlots();
+	~ImGuiPlots();
+
+	std::array<Plot, PlotCount> plots_;
+};

--- a/Plot/PlotDesc.h
+++ b/Plot/PlotDesc.h
@@ -1,0 +1,40 @@
+// Defines available plots.
+
+#pragma once
+#include <array>
+
+enum PlotType
+{
+	PLOT_FRAMETIME = 0,
+	PLOT_HOST_FRAMETIME,
+	PLOT_QUEUED_FRAMES,
+	PLOT_DROPPED_NETWORK,
+	PLOT_DROPPED_PACER,
+	PlotCount
+};
+
+enum PlotLabelType
+{
+	PLOT_LABEL_MIN_MAX_AVG = 0,
+	PLOT_LABEL_MIN_MAX_AVG_INT,
+	PLOT_LABEL_TOTAL_INT
+};
+
+struct PlotDesc
+{
+	const char *title;
+	PlotLabelType labelType;
+	const char *unit;
+	float scaleMin;
+	float scaleMax;
+	float scaleTarget;
+};
+
+// clang-format off
+inline constexpr std::array<PlotDesc, PlotCount> kPlotDescs = {{
+    {"Frametime",                      PLOT_LABEL_MIN_MAX_AVG, "ms", 0.0, 50.0, 0.0},
+    {"Host Frametime",                 PLOT_LABEL_MIN_MAX_AVG, "ms", 0.0, 50.0, 0.0},
+    {"Queued Frames",                  PLOT_LABEL_MIN_MAX_AVG,   "", 0.0, 5.0, 0.0},
+    {"Dropped Frames (network)",       PLOT_LABEL_TOTAL_INT,     "", 0.0, 5.0, 0.0},
+    {"Dropped Frames (pacing jitter)", PLOT_LABEL_TOTAL_INT,     "", 0.0, 5.0, 0.0},
+}};

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -33,7 +33,7 @@ void logDisplayMode(const char *str, HdmiDisplayMode^ mode) {
 	if (mode == nullptr) return;
 
 	char modeStr[256];
-	snprintf(modeStr, sizeof(modeStr), "%s: %s %ux%u @ %.2fhz, %u bpp, colorspace %s, pixel encoding %s\n",
+	snprintf(modeStr, sizeof(modeStr), "%s: %s %ux%u @ %.2fhz, %u bpp, %s, %s\n",
 		str,
 		mode->IsSmpte2084Supported ? "HDR" : "   ",
 		mode->ResolutionWidthInRawPixels, mode->ResolutionHeightInRawPixels,

--- a/State/Stats.cpp
+++ b/State/Stats.cpp
@@ -1,33 +1,29 @@
 #include "pch.h"
 #include "Stats.h"
 #include "Utils.hpp"
+#include "../Plot/ImGuiPlots.h"
 #include "../Streaming/FFMpegDecoder.h"
-
-extern "C" {
-	#include <Limelight.h>
-}
 
 using namespace moonlight_xbox_dx;
 
-static uint64_t QpcToUs(uint64_t qpc) {
-	static LARGE_INTEGER qpcFreq = {0, 0};
-	if (qpcFreq.QuadPart == 0) {
-		QueryPerformanceFrequency(&qpcFreq);
-	}
-
-	return (qpc * 1000000) / qpcFreq.QuadPart;
-}
-
-Stats::Stats()
+Stats::Stats() :
+	m_bandwidthBuffer(512),
+	m_decodeTimeBuffer(512)
 {
 	ZeroMemory(&m_ActiveWndVideoStats, sizeof(VIDEO_STATS));
 	ZeroMemory(&m_LastWndVideoStats, sizeof(VIDEO_STATS));
 	ZeroMemory(&m_GlobalVideoStats, sizeof(VIDEO_STATS));
 }
 
+// Called every frame, if true is returned, the stats text is refreshed
 bool Stats::ShouldUpdateDisplay(DX::StepTimer const& timer, bool isVisible, char* output, size_t length)
 {
 	bool shouldUpdate = false;
+
+	// when visible, data points for graphs are collected every frame
+	if (isVisible) {
+		m_bandwidthBuffer.push((float)m_bwTracker.GetAverageMbps());
+	}
 
 	// Process stats once per second
 	if (timer.GetTotalSeconds() - m_ActiveWndVideoStats.measurementStartTimestamp >= 1.0) {
@@ -62,14 +58,20 @@ bool Stats::ShouldUpdateDisplay(DX::StepTimer const& timer, bool isVisible, char
 //    Includes time spent in FEC reassembly
 // 3. Host processing latency (encode time)
 // 4. network packet loss (caller reports frame sequence number holes)
-void Stats::SubmitVideoBytesAndReassemblyTime(uint32_t length, uint32_t reassemblyMs, uint16_t frameHPL, uint32_t droppedFrames) {
+void Stats::SubmitVideoBytesAndReassemblyTime(uint32_t length, PDECODE_UNIT decodeUnit, uint32_t droppedFrames) {
 	std::lock_guard<std::mutex> lock(m_mutex);
-	m_bwTracker.AddBytes(length);
 	m_ActiveWndVideoStats.receivedFrames++;
 	m_ActiveWndVideoStats.totalFrames++;
+
+	// bandwidth
+	m_bwTracker.AddBytes(length);
+
+	// reassembly time
+	uint32_t reassemblyMs = (uint32_t)(decodeUnit->enqueueTimeMs - decodeUnit->receiveTimeMs);
 	m_ActiveWndVideoStats.totalReassemblyTime += reassemblyMs;
 
 	// Host processing latency
+	uint16_t frameHPL = decodeUnit->frameHostProcessingLatency;
 	if (frameHPL != 0) {
 		if (m_ActiveWndVideoStats.minHostProcessingLatency != 0) {
 			m_ActiveWndVideoStats.minHostProcessingLatency = std::min(m_ActiveWndVideoStats.minHostProcessingLatency, frameHPL);
@@ -78,15 +80,26 @@ void Stats::SubmitVideoBytesAndReassemblyTime(uint32_t length, uint32_t reassemb
 			m_ActiveWndVideoStats.minHostProcessingLatency = frameHPL;
 		}
 		m_ActiveWndVideoStats.framesWithHostProcessingLatency += 1;
+		m_ActiveWndVideoStats.maxHostProcessingLatency = std::max(m_ActiveWndVideoStats.maxHostProcessingLatency, frameHPL);
+		m_ActiveWndVideoStats.totalHostProcessingLatency += frameHPL;
 	}
-	m_ActiveWndVideoStats.maxHostProcessingLatency = std::max(m_ActiveWndVideoStats.maxHostProcessingLatency, frameHPL);
-	m_ActiveWndVideoStats.totalHostProcessingLatency += frameHPL;
 
 	// Network packet loss
 	if (droppedFrames > 0) {
 		m_ActiveWndVideoStats.networkDroppedFrames += droppedFrames;
 		m_ActiveWndVideoStats.totalFrames += droppedFrames;
 	}
+	ImGuiPlots::instance().observeFloat(PLOT_DROPPED_NETWORK, droppedFrames);
+
+	// Host frametime graph
+	static unsigned int lastHostPts = 0;
+	if (lastHostPts > 0) {
+		ImGuiPlots::instance().observeFloat(PLOT_HOST_FRAMETIME, (float)(decodeUnit->presentationTimeMs - lastHostPts));
+	}
+	lastHostPts = decodeUnit->presentationTimeMs;
+
+	// Queued frames for graph
+	ImGuiPlots::instance().observeFloat(PLOT_QUEUED_FRAMES, LiGetPendingVideoFrames());
 }
 
 // Time in milliseconds we spent decoding one frame, it is added up to later be divided by decodedFrames
@@ -94,55 +107,21 @@ void Stats::SubmitDecodeMs(double decodeMs) {
 	std::lock_guard<std::mutex> lock(m_mutex);
 	m_ActiveWndVideoStats.totalDecodeTime += decodeMs;
 	m_ActiveWndVideoStats.decodedFrames++;
+	m_decodeTimeBuffer.push((float)decodeMs);
+}
+
+void Stats::SubmitDroppedFrame(int count) {
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_ActiveWndVideoStats.pacerDroppedFrames += count;
 }
 
 // Time in microseconds for all rendering, including Update(), Render(), and Present().
 // Also increments the rendered frame count.
 void Stats::SubmitRenderTime(uint64_t renderTimeQpc) {
 	std::lock_guard<std::mutex> lock(m_mutex);
-	m_ActiveWndVideoStats.totalRenderTimeUs += QpcToUs(renderTimeQpc);
+	uint64_t renderTimeUs = QpcToUs(renderTimeQpc);
+	m_ActiveWndVideoStats.totalRenderTimeUs += renderTimeUs;
 	m_ActiveWndVideoStats.renderedFrames++;
-}
-
-void Stats::SubmitDXGIFrameStatistics(DXGI_FRAME_STATISTICS *frameStats) {
-	std::lock_guard<std::mutex> lock(m_mutex);
-
-	// frameStats->PresentCount;
-	// frameStats->PresentRefreshCount;
-	// frameStats->SyncRefreshCount;
-	// frameStats->SyncQPCTime;
-
-	// The values in PresentRefreshCount, SyncRefreshCount, and SyncQPCTime members of DXGI_FRAME_STATISTICS have the following characteristics:
-	// PresentRefreshCount is equal to SyncRefreshCount when the app presents on every vsync.
-	// SyncRefreshCount is obtained on the vsync interval when the present was submitted.
-	// SyncQPCTime is approximately the time associated with the vsync interval.
-
-	// Track glitches, from https://github.com/microsoft/DirectX-Graphics-Samples/blob/master/TechniqueDemos/D3D12MemoryManagement/src/Framework.cpp
-	if (frameStats->PresentCount > m_PreviousPresentCount) {
-		if (m_PreviousRefreshCount > 0 &&
-			(frameStats->PresentRefreshCount - m_PreviousRefreshCount) > (frameStats->PresentCount - m_PreviousPresentCount))
-		{
-			++m_GlitchCount;
-			m_ActiveWndVideoStats.dxGlitchCount++;
-		}
-	}
-
-	if (m_PreviousRefreshCount > 0) {
-		m_ActiveWndVideoStats.dxRefreshCountDiff = frameStats->PresentRefreshCount - m_PreviousRefreshCount;
-		m_ActiveWndVideoStats.dxPresentCountDiff = frameStats->PresentCount - m_PreviousPresentCount;
-	}
-
-	m_PreviousRefreshCount = frameStats->SyncRefreshCount;
-	m_PreviousPresentCount = frameStats->PresentCount;
-
-	// TODO: research this method of vsync frame pacing
-
-	// Microsoft covers this topic at:
-	// https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-flip-model#frame-synchronization-of-dxgi-flip-model-apps
-	// https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-flip-model#avoiding-detecting-and-recovering-from-glitches
-
-	// Some promising code around calculating estimated vsync timings and glitch recovery is in
-	// https://github.com/Emill/n64-fast3d-engine/blob/master/gfx_dxgi.cpp
 }
 
 /// private methods
@@ -153,6 +132,7 @@ void Stats::addVideoStats(DX::StepTimer const& timer, VIDEO_STATS& src, VIDEO_ST
 	dst.renderedFrames += src.renderedFrames;
 	dst.totalFrames += src.totalFrames;
 	dst.networkDroppedFrames += src.networkDroppedFrames;
+	dst.pacerDroppedFrames += src.pacerDroppedFrames;
 	dst.totalReassemblyTime += src.totalReassemblyTime;
 	dst.totalDecodeTime += src.totalDecodeTime;
 	dst.totalRenderTimeUs += src.totalRenderTimeUs;
@@ -176,10 +156,6 @@ void Stats::addVideoStats(DX::StepTimer const& timer, VIDEO_STATS& src, VIDEO_ST
 		// getting an RTT of 0. ENet currently ensures RTTs are >= 1.
 		assert(dst.lastRtt > 0);
 	}
-
-	dst.dxRefreshCountDiff = src.dxRefreshCountDiff; // these only store the most recent value
-	dst.dxPresentCountDiff = src.dxPresentCountDiff;
-	dst.dxGlitchCount += src.dxGlitchCount;
 
 	double now = timer.GetTotalSeconds();
 
@@ -327,6 +303,18 @@ void Stats::formatVideoStats(DX::StepTimer const& timer, VIDEO_STATS& stats, cha
 
 		offset += ret;
 	}
+	else {
+		// If all frames are duplicates this can happen, but let's avoid having the whole stats area change height
+		ret = snprintf(&output[offset],
+					   length - offset,
+					   "Host processing latency min/max/avg: -/-/- ms\n");
+		if (ret < 0 || ret >= length - offset) {
+			Utils::Log("Error: stringifyVideoStats length overflow\n");
+			return;
+		}
+
+		offset += ret;
+	}
 
 	if (stats.renderedFrames != 0) {
 		char rttString[32];
@@ -341,10 +329,12 @@ void Stats::formatVideoStats(DX::StepTimer const& timer, VIDEO_STATS& stats, cha
 		ret = snprintf(&output[offset],
 					   length - offset,
 					   "Frames dropped by your network connection: %.2f%%\n"
+					   "Frames dropped due to network jitter: %.2f%%\n"
 					   "Average network latency: %s\n"
 					   "Average reassembly/decoding time: %.2f/%.2f ms\n"
-					   "Average frametime: %.2f ms\n",
+					   "Average render time: %.2f ms\n",
 					   (double)stats.networkDroppedFrames / stats.totalFrames * 100,
+					   (double)stats.pacerDroppedFrames / stats.totalFrames * 100,
 					   rttString,
 					   (double)stats.totalReassemblyTime / stats.decodedFrames,
 					   (double)stats.totalDecodeTime / stats.decodedFrames,
@@ -356,18 +346,4 @@ void Stats::formatVideoStats(DX::StepTimer const& timer, VIDEO_STATS& stats, cha
 
 		offset += ret;
 	}
-
-#if defined(_DEBUG)
-	// Extra info only of interest to devs and not yet used for anything
-	ret = snprintf(&output[offset],
-					length - offset,
-					"dxRefreshCountDiff %d dxPresentCountDiff %d dxGlitchCount %d\n",
-					stats.dxRefreshCountDiff, stats.dxPresentCountDiff, stats.dxGlitchCount);
-	if (ret < 0 || ret >= length - offset) {
-		Utils::Log("Error: stringifyVideoStats length overflow\n");
-		return;
-	}
-
-	offset += ret;
-#endif
 }

--- a/Streaming/LogRenderer.cpp
+++ b/Streaming/LogRenderer.cpp
@@ -12,6 +12,7 @@ using namespace Microsoft::WRL;
 LogRenderer::LogRenderer(const std::shared_ptr<DX::DeviceResources>& deviceResources) :
 	m_console(std::make_unique<DX::TextConsole>()),
 	m_deviceResources(deviceResources),
+	m_mutex(),
 	m_visible(false)
 {
 	m_console->SetForegroundColor(Colors::Yellow);
@@ -23,6 +24,8 @@ LogRenderer::LogRenderer(const std::shared_ptr<DX::DeviceResources>& deviceResou
 // Updates the text to be displayed.
 void LogRenderer::Update(DX::StepTimer const& timer)
 {
+	std::lock_guard<std::mutex> lock(m_mutex);
+
 	// Only update the console once per second
 	static double lastUpdateSeconds = 0.0;
 	if (m_visible && timer.GetTotalSeconds() - lastUpdateSeconds >= 1.0) {
@@ -42,6 +45,7 @@ void LogRenderer::Update(DX::StepTimer const& timer)
 // Renders a frame to the screen.
 void LogRenderer::Render()
 {
+	std::lock_guard<std::mutex> lock(m_mutex);
 	if (m_visible) {
 		m_console->Render();
 	}
@@ -75,6 +79,7 @@ void LogRenderer::ReleaseDeviceDependentResources()
 	m_console->ReleaseDevice();
 }
 
-void LogRenderer::SetVisible(bool visible) {
-	m_visible = visible;
+void LogRenderer::ToggleVisible() {
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_visible = m_visible == true ? false : true;
 }

--- a/Streaming/LogRenderer.h
+++ b/Streaming/LogRenderer.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include <mutex>
 #include <string>
 #include "..\Common\StepTimer.h"
 #include "..\Common\TextConsole.h"
@@ -15,9 +16,11 @@ namespace moonlight_xbox_dx
 		void ReleaseDeviceDependentResources();
 		void Update(DX::StepTimer const& timer);
 		void Render();
-		void SetVisible(bool visible);
+		bool GetVisible() { return m_visible; }
+		void ToggleVisible();
 
 	private:
+		std::mutex                           m_mutex;
 		std::shared_ptr<DX::DeviceResources> m_deviceResources;
 		std::unique_ptr<DX::TextConsole>     m_console;
 		bool                                 m_visible;

--- a/Streaming/StatsRenderer.cpp
+++ b/Streaming/StatsRenderer.cpp
@@ -1,5 +1,9 @@
+// clang-format off
 #include "pch.h"
+// clang-format on
 #include "StatsRenderer.h"
+#include "../Plot/ImGuiPlots.h"
+#include "../Plot/PlotDesc.h"
 #include "FFMpegDecoder.h"
 #include "Utils.hpp"
 
@@ -8,24 +12,24 @@ using namespace moonlight_xbox_dx;
 using namespace Microsoft::WRL;
 using namespace Windows::UI::Core;
 
-StatsRenderer::StatsRenderer(const std::shared_ptr<DX::DeviceResources>& deviceResources, const std::shared_ptr<Stats>& stats) :
-	m_console(std::make_unique<DX::TextConsole>()),
-	m_deviceResources(deviceResources),
-	m_visible(false),
-	m_stats(stats)
+StatsRenderer::StatsRenderer(const std::shared_ptr<DX::DeviceResources> &deviceResources, const std::shared_ptr<Stats> &stats) :
+    m_console(std::make_unique<DX::TextConsole>()),
+    m_deviceResources(deviceResources),
+    m_mutex(),
+    m_visible(false),
+    m_stats(stats)
 {
 	m_console->SetForegroundColor(Colors::Yellow);
-	//m_console->SetDebugOutput(true);
+	// m_console->SetDebugOutput(true);
 
 	CreateDeviceDependentResources();
 }
 
-void StatsRenderer::Update(DX::StepTimer const& timer)
+void StatsRenderer::Update(DX::StepTimer const &timer)
 {
 	// We let the Stats class always process even if not visible. Most of the time
 	// it will simply accumulate stats during its 1-second window period. Each second,
 	// when it determines the user-visible text should be updated, it will update outputStr and return true.
-
 	char outputStr[1024]; // char is used so we can share more of the formatting code with moonlight-qt
 	wchar_t wideStr[2048];
 
@@ -39,18 +43,123 @@ void StatsRenderer::Update(DX::StepTimer const& timer)
 }
 
 // Renders a frame to the screen.
-void StatsRenderer::Render()
+void StatsRenderer::Render(bool showImGui)
 {
+	std::lock_guard<std::mutex> lock(m_mutex);
 	if (m_visible) {
 		m_console->Render();
+		if (showImGui) {
+			RenderGraphs();
+		}
 	}
+}
+
+void StatsRenderer::RenderGraphs()
+{
+	// we malloc a buffer for each stat only once and reuse it each frame
+	assert(PlotCount == 5);
+	static float *buffers[5] = {
+	    (float *)malloc(sizeof(float) * 512),
+	    (float *)malloc(sizeof(float) * 512),
+	    (float *)malloc(sizeof(float) * 512),
+	    (float *)malloc(sizeof(float) * 512),
+	    (float *)malloc(sizeof(float) * 512)};
+
+	ImGuiIO &io = ImGui::GetIO();
+
+	m_deviceResources->GetUWPPixelDimensions(&m_displayWidth, &m_displayHeight);
+	float graphW = 850.0f * (m_displayWidth / 3840.0f);
+	float graphH = 120.0f * (m_displayHeight / 2160.0f);
+	float opacity = 0.8f;
+
+	LogOnce("Drawing graphs of size %.1f x %.1f in viewport %d x %d using opacity %.2f\n",
+	        graphW, graphH, m_displayWidth, m_displayHeight, opacity);
+
+	// Row 1: 3 graphs
+	// Row 2: 2 graphs left-aligned
+	float itemSpacingX = ImGui::GetStyle().ItemSpacing.x;
+	float itemSpacingY = ImGui::GetStyle().ItemSpacing.y;
+	float row1Width = (3 * graphW) + (2 * itemSpacingX);
+	float totalHeight = (2 * graphH) + (2 * itemSpacingY) + 50;
+
+	// Anchor window to top-right
+	ImVec2 windowPos(m_displayWidth - 10.0f, 10.0f); // 10px margin
+	ImGui::SetNextWindowPos(windowPos, ImGuiCond_Always, ImVec2(1.0f, 0.0f));
+	ImGui::SetNextWindowSize(ImVec2(row1Width, totalHeight), ImGuiCond_Always);
+
+	ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
+	                         ImGuiWindowFlags_NoMove |
+	                         ImGuiWindowFlags_NoNavFocus |
+	                         ImGuiWindowFlags_NoBackground |
+	                         ImGuiWindowFlags_NoSavedSettings;
+	ImGui::Begin("##Stats", nullptr, flags);
+
+	auto draw_plot = [&](int i, float width, float height) {
+		Plot &plot = ImGuiPlots::instance().get(i);
+
+		float minY = 0.0f;
+		float maxY = 0.0f;
+		size_t countF = plot.buffer.copyInto(buffers[i], minY, maxY);
+		float avgF = plot.buffer.average();
+		if (!countF) {
+			return;
+		}
+
+		char label[64];
+		switch (plot.desc.labelType) {
+		case PLOT_LABEL_MIN_MAX_AVG:
+			sprintf(label, "%s  %.1f / %.1f / %.1f %s", plot.desc.title, minY, maxY, avgF, plot.desc.unit);
+			break;
+		case PLOT_LABEL_MIN_MAX_AVG_INT:
+			sprintf(label, "%s  %d / %d / %.1f %s", plot.desc.title, (int)minY, (int)maxY, avgF, plot.desc.unit);
+			break;
+		case PLOT_LABEL_TOTAL_INT:
+			sprintf(label, "%s  %d %s", plot.desc.title, (int)plot.buffer.sum(), plot.desc.unit);
+			break;
+		}
+		float scaleMin = FLT_MAX;
+		float scaleMax = FLT_MAX;
+		if (plot.desc.scaleTarget) {
+			// optionally center the graph on a target such as the ideal frametime
+			float ideal = (float)plot.desc.scaleTarget;
+			scaleMin = ideal - (2 * ideal);
+			scaleMax = ideal + (2 * ideal);
+		}
+		if (plot.desc.scaleMin)
+			scaleMin = plot.desc.scaleMin;
+		if (plot.desc.scaleMax)
+			scaleMax = plot.desc.scaleMax;
+
+		ImGui::PushID(i);
+		ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.19f, 0.19f, 0.19f, opacity)); // dark
+		ImGui::PushStyleColor(ImGuiCol_PlotLines, ImVec4(0.0f, 1.0f, 0.0f, 1.0f));     // green
+		ImGui::PlotLines("##xx", buffers[i], countF, 0, (countF > 0 ? label : "no data"), scaleMin, scaleMax, ImVec2(width, height));
+		ImGui::PopStyleColor(2);
+		ImGui::PopID();
+	};
+
+	// Row 1: A, C, E  -> indices {0,2,4}
+	const int row1[3] = {PLOT_FRAMETIME, PLOT_DROPPED_NETWORK, PLOT_QUEUED_FRAMES};
+	for (int c = 0; c < 3; ++c) {
+		if (c > 0) ImGui::SameLine(0.0f, itemSpacingX);
+		draw_plot(row1[c], graphW, graphH);
+	}
+
+	// Row 2: B, D  (indices 1,3), aligned left under row1 col1 and col2
+	ImGui::Dummy(ImVec2(1.0f, itemSpacingY));
+	const int row2[2] = {PLOT_HOST_FRAMETIME, PLOT_DROPPED_PACER};
+	draw_plot(row2[0], graphW, graphH);
+	ImGui::SameLine(0.0f, itemSpacingX);
+	draw_plot(row2[1], graphW, graphH);
+
+	ImGui::End();
 }
 
 void StatsRenderer::CreateDeviceDependentResources()
 {
 	m_deviceResources->GetUWPPixelDimensions(&m_displayWidth, &m_displayHeight);
 
-	const wchar_t* font = L"Assets\\Font\\ModeSeven-24.spritefont"; // sized for 4K
+	const wchar_t *font = L"Assets\\Font\\ModeSeven-24.spritefont"; // sized for 4K
 	if (m_displayHeight <= 1440) {
 		font = L"Assets\\Font\\ModeSeven-12.spritefont"; // for 1080p & 1440p
 	}
@@ -74,6 +183,8 @@ void StatsRenderer::ReleaseDeviceDependentResources()
 	m_console->ReleaseDevice();
 }
 
-void StatsRenderer::SetVisible(bool visible) {
-	m_visible = visible;
+void StatsRenderer::ToggleVisible()
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_visible = m_visible == true ? false : true;
 }

--- a/Streaming/StatsRenderer.h
+++ b/Streaming/StatsRenderer.h
@@ -1,32 +1,36 @@
 #pragma once
 
-#include <memory>
-#include <mutex>
-#include <string>
 #include "..\Common\StepTimer.h"
 #include "..\Common\TextConsole.h"
 #include "..\State\Stats.h"
+#include <memory>
+#include <mutex>
+#include <string>
 
-namespace moonlight_xbox_dx
+namespace moonlight_xbox_dx {
+class StatsRenderer
 {
-	class StatsRenderer
+  public:
+	StatsRenderer(const std::shared_ptr<DX::DeviceResources> &deviceResources, const std::shared_ptr<Stats> &stats);
+	void CreateDeviceDependentResources();
+	void CreateWindowSizeDependentResources();
+	void ReleaseDeviceDependentResources();
+	void Update(DX::StepTimer const &timer);
+	void Render(bool showImGui);
+	void RenderGraphs();
+	bool GetVisible()
 	{
-	public:
-		StatsRenderer(const std::shared_ptr<DX::DeviceResources>& deviceResources, const std::shared_ptr<Stats>& stats);
-		void CreateDeviceDependentResources();
-		void CreateWindowSizeDependentResources();
-		void ReleaseDeviceDependentResources();
-		void Update(DX::StepTimer const& timer);
-		void Render();
-		void SetVisible(bool visible);
+		return m_visible;
+	}
+	void ToggleVisible();
 
-	private:
-		std::mutex                                m_mutex;
-		std::shared_ptr<DX::DeviceResources>      m_deviceResources;
-		std::unique_ptr<DX::TextConsole>          m_console;
-		std::shared_ptr<Stats>                    m_stats;
-		bool                                      m_visible;
-		uint32_t                                  m_displayWidth;
-		uint32_t                                  m_displayHeight;
-	};
-}
+  private:
+	std::mutex m_mutex;
+	std::shared_ptr<DX::DeviceResources> m_deviceResources;
+	std::unique_ptr<DX::TextConsole> m_console;
+	std::shared_ptr<Stats> m_stats;
+	bool m_visible;
+	uint32_t m_displayWidth;
+	uint32_t m_displayHeight;
+};
+} // namespace moonlight_xbox_dx

--- a/Streaming/VideoRenderer.cpp
+++ b/Streaming/VideoRenderer.cpp
@@ -109,8 +109,6 @@ bool VideoRenderer::Render()
 		return true;
 	}
 	//Create a rendering texture
-	LARGE_INTEGER start;
-	QueryPerformanceCounter(&start);
 	FFMpegDecoder::getInstance()->shouldUnlock = false;
 	if (!FFMpegDecoder::getInstance()->SubmitDU()) {
 		return false;

--- a/Streaming/moonlight_xbox_dxMain.h
+++ b/Streaming/moonlight_xbox_dxMain.h
@@ -32,12 +32,14 @@ namespace moonlight_xbox_dx
 		void CloseApp();
 		void SendGuideButton(int duration);
 		void SendWinAltB();
-		void SetShowLogs(bool showLogs);
-		void SetShowStats(bool showStats);
+		bool ToggleLogs();
+		bool ToggleStats();
+		void SetImGui(bool isVisible);
 	private:
 		void ProcessInput();
 		void Update();
 		bool Render();
+		void RenderImGui();
 		void Clear();
 
 		// Cached pointer to device resources.

--- a/TODO
+++ b/TODO
@@ -6,8 +6,4 @@ Remember stats enabled status in a host pref
 
 Changing vsync mode requires a full swapchain reset
 
-Look into GetFrameStatistics() and frame pacing techniques
-    https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-flip-model
-    See SubmitDXGIFrameStatistics() for more links
-
 When changing the Windows HDR calibration profile on the host, it causes the stream to reset and often switch to the wrong colorspace.

--- a/Utils.cpp
+++ b/Utils.cpp
@@ -39,7 +39,7 @@ namespace moonlight_xbox_dx {
 
 			return ref new Platform::String(NarrowToWideString(std::string_view(message.data())).c_str());
 		}
-    
+
     std::wstring GetCurrentTimestamp() {
 			auto now = system_clock::now().time_since_epoch();
 			auto min = duration_cast<minutes>(now) % 60;

--- a/Utils/FloatBuffer.cpp
+++ b/Utils/FloatBuffer.cpp
@@ -1,0 +1,179 @@
+#include "pch.h"
+#include "FloatBuffer.h"
+#include "../Utils.hpp"
+
+#include <algorithm>
+#include <cfloat>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+
+using namespace moonlight_xbox_dx;
+
+FloatBuffer::FloatBuffer(std::size_t capacity) :
+    buffer_(capacity),
+    capacity_(capacity),
+    count_(0),
+    head_(0),
+    min_(FLT_MAX),
+    max_(-FLT_MAX),
+    sum_(0.0f)
+{
+	if (!is_power_of_two(capacity_)) {
+		throw std::invalid_argument("FloatBuffer capacity must be a power of two");
+	}
+}
+
+void FloatBuffer::push(float value) noexcept
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+
+	const bool was_full = (count_ == capacity_);
+	float evicted = 0.0f;
+
+	if (was_full) {
+		// We are about to overwrite the oldest value at head_.
+		evicted = buffer_[head_];
+		sum_ -= static_cast<double>(evicted);
+	} else {
+		++count_;
+	}
+
+	buffer_[head_] = value;
+	head_ = (head_ + 1) & (capacity_ - 1);
+
+	// Update cheap aggregates.
+	sum_ += static_cast<double>(value);
+	if (value < min_) min_ = value;
+	if (value > max_) max_ = value;
+
+	// If we evicted the current min or max, recompute
+	if (was_full && (evicted == min_ || evicted == max_)) {
+		recompute_min_max_unsafe();
+	}
+}
+
+std::size_t FloatBuffer::copyInto(float *outBuffer, float &out_min, float &out_max) const
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+
+	if (count_ == 0) {
+		out_min = 0.0f;
+		out_max = 0.0f;
+		return 0;
+	}
+
+	// Oldest element lives at tail.
+	const std::size_t tail = (head_ + capacity_ - count_) & (capacity_ - 1);
+	const std::size_t first = std::min(capacity_ - tail, count_);
+
+	// First contiguous chunk.
+	std::memcpy(outBuffer, buffer_.data() + tail, first * sizeof(float));
+
+	// If wrapped, copy remaining prefix from index 0.
+	if (first < count_) {
+		std::memcpy(outBuffer + first, buffer_.data(), (count_ - first) * sizeof(float));
+	}
+
+	out_min = min_;
+	out_max = max_;
+	return count_;
+}
+
+void FloatBuffer::clear() noexcept
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+	head_ = 0;
+	count_ = 0;
+	min_ = FLT_MAX;
+	max_ = -FLT_MAX;
+	sum_ = 0.0f;
+	// Note: we intentionally do not zero buffer_ for performance.
+}
+
+std::size_t FloatBuffer::size() const noexcept
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+	return count_;
+}
+
+bool FloatBuffer::is_full() const noexcept
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+	return count_ == capacity_;
+}
+
+float FloatBuffer::average() const noexcept
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+	return (count_ > 0) ? static_cast<float>(sum_ / static_cast<double>(count_)) : 0.0f;
+}
+
+double FloatBuffer::sum() const noexcept
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+	return (count_ > 0) ? sum_ : 0.0f;
+}
+
+bool FloatBuffer::is_power_of_two(std::size_t x) noexcept
+{
+	return x != 0 && (x & (x - 1)) == 0;
+}
+
+void FloatBuffer::recompute_min_max_unsafe() noexcept
+{
+	float mn = FLT_MAX;
+	float mx = -FLT_MAX;
+
+	const std::size_t tail = (head_ + capacity_ - count_) & (capacity_ - 1);
+	const std::size_t first = std::min(capacity_ - tail, count_);
+
+	const float *p0 = buffer_.data() + tail;
+	for (std::size_t i = 0; i < first; ++i) {
+		const float v = p0[i];
+		if (v < mn) mn = v;
+		if (v > mx) mx = v;
+	}
+
+	if (first < count_) {
+		const float *p1 = buffer_.data();
+		for (std::size_t i = 0; i < (count_ - first); ++i) {
+			const float v = p1[i];
+			if (v < mn) mn = v;
+			if (v > mx) mx = v;
+		}
+	}
+
+	min_ = mn;
+	max_ = mx;
+}
+
+void FloatBuffer::dump() const noexcept
+{
+	std::lock_guard<std::mutex> lock(mtx_);
+
+	if (count_ == 0) {
+		Utils::Logf("[FloatBuffer empty]\n");
+		return;
+	}
+
+	std::ostringstream oss;
+	oss << "[FloatBuffer size=" << count_ << "/" << capacity_ << "] ";
+
+	// Start from oldest element
+	std::size_t tail = (head_ + capacity_ - count_) & (capacity_ - 1);
+	std::size_t first = std::min(capacity_ - tail, count_);
+
+	// first contiguous segment
+	for (std::size_t i = 0; i < first; ++i) {
+		if (i > 0) oss << ',';
+		oss << buffer_[tail + i];
+	}
+
+	// wraparound segment
+	for (std::size_t i = 0; i < count_ - first; ++i) {
+		oss << ',' << buffer_[i];
+	}
+
+	Utils::Logf("%s\n", oss.str().c_str());
+}

--- a/Utils/FloatBuffer.h
+++ b/Utils/FloatBuffer.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstddef>
+#include <mutex>
+#include <vector>
+
+class FloatBuffer
+{
+  public:
+	static constexpr std::size_t kDefaultCapacity = 512;
+
+	explicit FloatBuffer(std::size_t capacity = kDefaultCapacity);
+
+	void push(float value) noexcept;
+	std::size_t copyInto(float *outBuffer, float &out_min, float &out_max) const;
+	void clear() noexcept;
+
+	std::size_t capacity() const noexcept
+	{
+		return capacity_;
+	}
+	bool is_full() const noexcept;
+	std::size_t size() const noexcept;
+
+	float average() const noexcept;
+	double sum() const noexcept;
+
+	void dump() const noexcept;
+
+  private:
+	static bool is_power_of_two(std::size_t x) noexcept;
+	void recompute_min_max_unsafe() noexcept;
+
+  private:
+	std::vector<float> buffer_;  // backing storage, length == capacity_
+	const std::size_t capacity_; // power of two
+	std::size_t count_;          // number of valid elements (0..capacity_)
+	std::size_t head_;           // index where the next push will write
+	float min_;                  // current minimum across valid window
+	float max_;                  // current maximum across valid window
+	double sum_;                 // running sum for O(1) average
+	mutable std::mutex mtx_;     // guards all mutable state
+};

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -136,7 +136,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageDir>C:\Progetti\moonlight-xbox-dx\AppPackages\moonlight-xbox-dx\</AppxPackageDir>
-	<PackageCertificateKeyFile>moonlight-xbox-dx_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateKeyFile>moonlight-xbox-dx_TemporaryKey.pfx</PackageCertificateKeyFile>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>
@@ -242,7 +242,7 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)\third_party\DirectXTK\inc;$(ProjectDir)vcpkg_installed\x64-uwp\include;$(IntermediateOutputPath);third_party\moonlight-common-c\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)\third_party\DirectXTK\inc;$(ProjectDir)vcpkg_installed\x64-uwp\include;$(IntermediateOutputPath);third_party\moonlight-common-c\src;third_party\imgui;third_party\imgui\backends;third_party\imgui-uwp\backends;third_party\implot;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
@@ -261,7 +261,7 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)\third_party\DirectXTK\inc;$(ProjectDir)vcpkg_installed\x64-uwp\include;$(IntermediateOutputPath);third_party\moonlight-common-c\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)\third_party\DirectXTK\inc;$(ProjectDir)vcpkg_installed\x64-uwp\include;$(IntermediateOutputPath);third_party\moonlight-common-c\src;third_party\imgui;third_party\imgui\backends;third_party\imgui-uwp\backends;third_party\implot;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
@@ -326,6 +326,7 @@
     <ClInclude Include="App.xaml.h">
       <DependentUpon>App.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Common\imconfig.moonlight.h" />
     <ClInclude Include="Common\TextConsole.h" />
     <ClInclude Include="MoonlightWelcome.xaml.h">
       <DependentUpon>MoonlightWelcome.xaml</DependentUpon>
@@ -334,6 +335,8 @@
       <DependentUpon>KeyboardControl.xaml</DependentUpon>
     </ClInclude>
     <ClInclude Include="Keyboard\KeyboardCommon.h" />
+    <ClInclude Include="Plot\ImGuiPlots.h" />
+    <ClInclude Include="Plot\PlotDesc.h" />
     <ClInclude Include="State\BandwidthTracker.h" />
     <ClInclude Include="State\MoonlightClient.h" />
     <ClInclude Include="State\Stats.h" />
@@ -370,6 +373,7 @@
     <ClInclude Include="Streaming\FFmpegDecoder.h" />
     <ClInclude Include="Streaming\moonlight_xbox_dxMain.h" />
     <ClInclude Include="Utils.hpp" />
+    <ClInclude Include="Utils\FloatBuffer.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="App.xaml.cpp">
@@ -466,6 +470,7 @@
     <ClCompile Include="MoonlightWelcome.xaml.cpp">
       <DependentUpon>MoonlightWelcome.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="Plot\ImGuiPlots.cpp" />
     <ClCompile Include="State\BandwidthTracker.cpp" />
     <ClCompile Include="State\MoonlightClient.cpp" />
     <ClCompile Include="State\Stats.cpp" />
@@ -507,7 +512,36 @@
     <ClCompile Include="Streaming\AudioPlayer.cpp" />
     <ClCompile Include="Streaming\FFmpegDecoder.cpp" />
     <ClCompile Include="Streaming\moonlight_xbox_dxMain.cpp" />
+    <ClCompile Include="third_party\imgui-uwp\backends\imgui_impl_uwp.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\backends\imgui_impl_dx11.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_demo.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_draw.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_tables.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_widgets.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="Utils.cpp" />
+    <ClCompile Include="Utils\FloatBuffer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest">

--- a/moonlight-xbox-dx.vcxproj.filters
+++ b/moonlight-xbox-dx.vcxproj.filters
@@ -28,6 +28,9 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>hlsl</Extensions>
     </Filter>
+    <Filter Include="ImGui">
+      <UniqueIdentifier>{c5fa3ea7-182b-41f7-91ef-1c48589370b7}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Streaming\YUVRGBPixelShader.hlsl">
@@ -350,6 +353,33 @@
     <ClCompile Include="State\Stats.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_widgets.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_demo.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_draw.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\backends\imgui_impl_dx11.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui-uwp\backends\imgui_impl_uwp.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui_tables.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="third_party\imgui\imgui.cpp">
+      <Filter>ImGui</Filter>
+    </ClCompile>
+    <ClCompile Include="Plot\ImGuiPlots.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\FloatBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="State\MoonlightClient.h">
@@ -419,6 +449,18 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="State\Stats.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Common\imconfig.moonlight.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\FloatBuffer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Plot\ImGuiPlots.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Plot\PlotDesc.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
@@ -581,6 +623,1227 @@
     <AppxManifest Include="Package.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
+      <Filter>DLLs</Filter>
+    </CopyFileToFolders>
     <CopyFileToFolders Include="vcpkg_installed\x64-uwp\bin\*">
       <Filter>DLLs</Filter>
     </CopyFileToFolders>

--- a/pch.h
+++ b/pch.h
@@ -17,11 +17,70 @@
 #include <DirectXMath.h>
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <agile.h>
 #include <concrt.h>
 #include <collection.h>
 #include "App.xaml.h"
 
+#define IMGUI_USER_CONFIG "Common\imconfig.moonlight.h"
+#include <imgui.h>
+#include <imgui_impl_uwp.h>
+#include <imgui_impl_dx11.h>
+
 #ifdef _DEBUG
 #include <dxgidebug.h>
 #endif
+
+// Helper for dispatching code to the UI thread
+#define DISPATCH_UI(CAPTURE, CODE)                                           \
+	Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow   \
+		->Dispatcher                                                         \
+		->RunAsync(                                                          \
+			Windows::UI::Core::CoreDispatcherPriority::High,                 \
+			ref new Windows::UI::Core::DispatchedHandler(CAPTURE CODE)       \
+		)
+
+// Time helpers
+static uint64_t QpcToUs(uint64_t qpc) {
+	static LARGE_INTEGER qpcFreq = {0, 0};
+	if (qpcFreq.QuadPart == 0) {
+		QueryPerformanceFrequency(&qpcFreq);
+	}
+
+	return (qpc * 1000000) / qpcFreq.QuadPart;
+}
+
+static uint64_t QpcToNs(uint64_t qpc) {
+    // Convert QPC units (1/perf_freq seconds) to nanoseconds. This will work
+    // without overflow because the QPC value is guaranteed not to roll-over
+    // within 100 years, so perf_freq must be less than 2.9*10^9.
+	static LARGE_INTEGER qpcFreq = {0, 0};
+	if (qpcFreq.QuadPart == 0) {
+		QueryPerformanceFrequency(&qpcFreq);
+	}
+
+    return qpc / qpcFreq.QuadPart * UINT64_C(1000000000) +
+        qpc % qpcFreq.QuadPart * UINT64_C(1000000000) / qpcFreq.QuadPart;
+}
+
+static uint64_t QpcNsNow() {
+    LARGE_INTEGER perf_count;
+    QueryPerformanceCounter(&perf_count);
+    return QpcToNs(perf_count.QuadPart);
+}
+
+static double QpcToMs(uint64_t qpc) {
+	return (double)QpcToUs(qpc) / 1000.0f;
+}
+
+// Log something only once, safe to use in hot areas of the code
+#define CONCAT(a, b)   CONCAT2(a, b)
+#define CONCAT2(a, b)  a##b
+#define LogOnce(fmt, ...)                                    \
+    do {                                                     \
+        static std::once_flag CONCAT(_onceFlag_, __LINE__);  \
+        std::call_once(CONCAT(_onceFlag_, __LINE__), [&] {   \
+            Utils::Logf(fmt, ##__VA_ARGS__);                 \
+        });                                                  \
+    } while (0)

--- a/third_party/imgui-uwp/LICENSE
+++ b/third_party/imgui-uwp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ahmed Walid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/imgui-uwp/backends/imgui_impl_uwp.cpp
+++ b/third_party/imgui-uwp/backends/imgui_impl_uwp.cpp
@@ -1,0 +1,1172 @@
+// dear imgui: Platform Backend for Universal Windows Platform (standard windows API for 32-bits AND 64-bits applications)
+// This needs to be used along with a Renderer (e.g. DirectX11, DirectX12, SDL2..)
+
+// Implemented features:
+//  [X] Platform: Clipboard support (for Win32 & UWP this is actually part of core dear imgui)
+//  [X] Platform: Mouse support. Can discriminate Mouse/TouchScreen/Pen.
+//  [X] Platform: Keyboard support. Since 1.87 we are using the io.AddKeyEvent() function. Pass ImGuiKey values to all key functions e.g. ImGui::IsKeyPressed(ImGuiKey_Space).
+//  [X] Platform: Gamepad support. Enabled with 'io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad'.
+//  [X] Platform: Mouse cursor shape and visibility. Disable with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'.
+
+// You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
+// Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
+// If you are new to Dear ImGui, read documentation from the docs/ folder + read the top of imgui.cpp.
+// Read online: https://github.com/ocornut/imgui/tree/master/docs
+
+#include "imgui.h"
+#include "imgui_impl_uwp.h"
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <sdkddkver.h>
+#include <tchar.h>
+#include <wrl.h>
+
+//WinRT
+#include <Windows.UI.Core.h>
+#include <CoreWindow.h>
+#include <Windows.UI.Xaml.Controls.h>
+#include <Windows.UI.Xaml.Hosting.h>
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+
+// Disabling XInput on older SDKs that didn't allow LoadLibrary for the Application Family
+#if  (NTDDI_VERSION < NTDDI_WIN10_CO)
+#define IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+#endif
+
+// Using XInput for gamepad (will load DLL dynamically)
+#ifndef IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+#include <xinput.h>
+typedef DWORD (WINAPI *PFN_XInputGetCapabilities)(DWORD, DWORD, XINPUT_CAPABILITIES*);
+typedef DWORD (WINAPI *PFN_XInputGetState)(DWORD, XINPUT_STATE*);
+#endif
+
+// From CoreWindow.h
+
+typedef HRESULT(_cdecl* PFN_CreateControlInput)(_In_ REFIID riid, _COM_Outptr_ void** ppv);
+typedef HRESULT(_cdecl* PFN_CreateControlInputEx)(_In_ IUnknown* pCoreWindow, _In_ REFIID riid, _COM_Outptr_ void** ppv);
+
+MIDL_INTERFACE("40BFE3E3-B75A-4479-AC96-475365749BB8")
+ISystemCoreInputInterop : public IUnknown
+{
+public:
+    virtual HRESULT STDMETHODCALLTYPE SetInputSource(__RPC__in_opt ::IUnknown * value) PURE;
+    virtual HRESULT STDMETHODCALLTYPE put_MessageHandled(boolean value) PURE;
+};
+
+// Clipboard support
+#if !defined(IMGUI_DISABLE_UWP_DEFAULT_CLIPBOARD_FUNCTIONS)
+#include "imgui_internal.h"
+#include <windows.applicationmodel.datatransfer.h>
+
+static const char* ImGui_ImplUwp_GetClipboardTextFn(void* user_data_ctx);
+static void        ImGui_ImplUwp_SetClipboardTextFn(void* user_data_ctx, const char* text);
+#endif
+
+struct ImGui_ImplUwp_Data
+{
+    ABI::Windows::UI::Core::ICoreWindow*               CoreWindow;
+    ABI::Windows::UI::Xaml::Controls::ISwapChainPanel* SwapChainPanel;
+    ABI::Windows::UI::Xaml::IFrameworkElement*         SwapChainPanelElement;
+    ABI::Windows::UI::Core::ICorePointerInputSource*   PointerInputSource;
+    ABI::Windows::UI::Core::ICoreKeyboardInputSource*  KeyboardInputSource;
+    int                                                MouseTrackedArea;   // 0: not tracked, 1: client area, 2: non-client area
+    int                                                MouseButtonsDown;
+    INT64                                              Time;
+    INT64                                              TicksPerSecond;
+    ImGuiMouseCursor                                   LastMouseCursor;
+
+    ::EventRegistrationToken                           PointerMovedToken;
+    ::EventRegistrationToken                           PointerExitedToken;
+    ::EventRegistrationToken                           KeyDownToken;
+    ::EventRegistrationToken                           KeyUpToken;
+    ::EventRegistrationToken                           CharacterReceivedToken;
+    ::EventRegistrationToken                           PointerWheelChangedToken;
+    ::EventRegistrationToken                           WindowActivatedToken;
+    ::EventRegistrationToken                           PointerPressedToken;
+    ::EventRegistrationToken                           PointerReleasedToken;
+
+#ifndef IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+    bool                        HasGamepad;
+    bool                        WantUpdateHasGamepad;
+    HMODULE                     XInputDLL;
+    PFN_XInputGetCapabilities   XInputGetCapabilities;
+    PFN_XInputGetState          XInputGetState;
+#endif
+
+    ImGui_ImplUwp_Data()      { memset((void*)this, 0, sizeof(*this)); }
+};
+
+typedef ABI::Windows::Foundation::ITypedEventHandler<::IInspectable*, ABI::Windows::UI::Core::PointerEventArgs*> PointerMoved_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<::IInspectable*, ABI::Windows::UI::Core::PointerEventArgs*> PointerExited_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<::IInspectable*, ABI::Windows::UI::Core::KeyEventArgs*> KeyDown_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<::IInspectable*, ABI::Windows::UI::Core::CharacterReceivedEventArgs*> CharacterReceived_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<::IInspectable*, ABI::Windows::UI::Core::PointerEventArgs*> PointerWheelChanged_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<::IInspectable*, ABI::Windows::UI::Core::PointerEventArgs*> PointerPressed_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<::IInspectable*, ABI::Windows::UI::Core::PointerEventArgs*> PointerReleased_Callback;
+int PointerMoved(::IInspectable*, ABI::Windows::UI::Core::IPointerEventArgs*);
+int PointerExited(::IInspectable*, ABI::Windows::UI::Core::IPointerEventArgs*);
+int KeyDown(::IInspectable*, ABI::Windows::UI::Core::IKeyEventArgs*);
+int KeyUp(::IInspectable*, ABI::Windows::UI::Core::IKeyEventArgs*);
+int CharacterReceived(::IInspectable*, ABI::Windows::UI::Core::ICharacterReceivedEventArgs*);
+int PointerWheelChanged(::IInspectable*, ABI::Windows::UI::Core::IPointerEventArgs*);
+int PointerPressed(::IInspectable*, ABI::Windows::UI::Core::IPointerEventArgs*);
+int PointerReleased(::IInspectable*, ABI::Windows::UI::Core::IPointerEventArgs*);
+
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::PointerEventArgs*> WindowPointerMoved_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::PointerEventArgs*> WindowPointerExited_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::KeyEventArgs*> WindowKeyDown_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::CharacterReceivedEventArgs*> WindowCharacterReceived_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::PointerEventArgs*> WindowPointerWheelChanged_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::PointerEventArgs*> WindowPointerPressed_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::PointerEventArgs*> WindowPointerReleased_Callback;
+typedef ABI::Windows::Foundation::ITypedEventHandler<ABI::Windows::UI::Core::CoreWindow*, ABI::Windows::UI::Core::WindowActivatedEventArgs*> WindowActivated_Callback;
+int WindowActivated(ABI::Windows::UI::Core::ICoreWindow*, ABI::Windows::UI::Core::IWindowActivatedEventArgs*);
+
+// Backend data stored in io.BackendPlatformUserData to allow support for multiple Dear ImGui contexts
+// It is STRONGLY preferred that you use docking branch with multi-viewports (== single Dear ImGui context + multiple windows) instead of multiple Dear ImGui contexts.
+// FIXME: multi-context support is not well tested and probably dysfunctional in this backend.
+// FIXME: some shared resources (mouse cursor shape, gamepad) are mishandled when using multi-context.
+static ImGui_ImplUwp_Data* ImGui_ImplUwp_GetBackendData()
+{
+    return ImGui::GetCurrentContext() ? (ImGui_ImplUwp_Data*)ImGui::GetIO().BackendPlatformUserData : nullptr;
+}
+
+static ABI::Windows::UI::Core::ICoreWindow* ImGui_ImplUwp_GetCoreWindowForCurrentThread()
+{
+    ComPtr<ABI::Windows::UI::Core::ICoreWindowStatic> windowStatic;
+    ABI::Windows::UI::Core::ICoreWindow* window = nullptr;
+
+    Windows::Foundation::GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Core_CoreWindow).Get(), &windowStatic);
+
+    if (windowStatic->GetForCurrentThread(&window) != S_OK)
+        return nullptr;
+
+	return window;
+}
+
+// Functions
+static bool ImGui_ImplUwp_InitEx(ABI::Windows::UI::Core::ICoreWindow* core_window, ABI::Windows::UI::Xaml::Controls::ISwapChainPanel* swapchain_panel, bool is_for_current_view)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    IM_ASSERT(io.BackendPlatformUserData == nullptr && "Already initialized a platform backend!");
+
+    INT64 perf_frequency, perf_counter;
+    if (!::QueryPerformanceFrequency((LARGE_INTEGER*)&perf_frequency))
+        return false;
+    if (!::QueryPerformanceCounter((LARGE_INTEGER*)&perf_counter))
+        return false;
+
+    // Setup backend capabilities flags
+    ImGui_ImplUwp_Data* bd = IM_NEW(ImGui_ImplUwp_Data)();
+    io.BackendPlatformUserData = (void*)bd;
+    io.BackendPlatformName = "imgui_impl_uwp";
+    io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;         // We can honor GetMouseCursor() values (optional)
+    io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;          // We can honor io.WantSetMousePos requests (optional, rarely used)
+
+    // Clipboard support
+#if !defined(IMGUI_DISABLE_UWP_DEFAULT_CLIPBOARD_FUNCTIONS)
+    io.GetClipboardTextFn = ImGui_ImplUwp_GetClipboardTextFn;
+    io.SetClipboardTextFn = ImGui_ImplUwp_SetClipboardTextFn;
+#endif
+
+    if (core_window && !is_for_current_view)
+        core_window->AddRef();
+
+    if (swapchain_panel)
+    {
+        swapchain_panel->AddRef();
+		swapchain_panel->QueryInterface(&bd->SwapChainPanelElement);
+    }
+
+    bd->CoreWindow = core_window;
+    bd->SwapChainPanel = swapchain_panel;
+    bd->TicksPerSecond = perf_frequency;
+    bd->Time = perf_counter;
+    bd->LastMouseCursor = ImGuiMouseCursor_COUNT;
+
+    // Set platform dependent data in viewport
+    ImGui::GetMainViewport()->PlatformHandleRaw = (void*)core_window;
+
+    // Dynamically load XInput library
+#ifndef IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+    bd->WantUpdateHasGamepad = true;
+    const char* xinput_dll_names[] =
+    {
+        "xinput1_4.dll",   // Windows 8+
+        "xinput1_3.dll",   // DirectX SDK
+        "xinput9_1_0.dll", // Windows Vista, Windows 7
+        "xinput1_2.dll",   // DirectX SDK
+        "xinput1_1.dll",   // DirectX SDK
+        "xinputuap.dll"    // OneCoreUAP
+    };
+    for (int n = 0; n < IM_ARRAYSIZE(xinput_dll_names); n++)
+        if (HMODULE dll = ::LoadLibraryA(xinput_dll_names[n]))
+        {
+            bd->XInputDLL = dll;
+            bd->XInputGetCapabilities = (PFN_XInputGetCapabilities)::GetProcAddress(dll, "XInputGetCapabilities");
+            bd->XInputGetState = (PFN_XInputGetState)::GetProcAddress(dll, "XInputGetState");
+            break;
+        }
+#endif // IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+
+    /*ComPtr<::IUnknown> controlInput;
+
+	auto winUI = LoadLibraryW(L"Windows.UI.dll");
+	auto SystemCreateControlInput = (PFN_CreateControlInput)GetProcAddress(winUI, "CreateControlInput");
+	auto SystemCreateControlInputEx = (PFN_CreateControlInputEx)GetProcAddress(winUI, "CreateControlInputEx");
+
+    if (core_window)
+    {
+        bd->CoreWindow->add_Activated(Callback<WindowActivated_Callback>(WindowActivated).Get(), &bd->WindowActivatedToken);
+        SystemCreateControlInputEx(core_window, ABI::Windows::UI::Core::IID_ICoreInputSourceBase, &controlInput);
+    }*/
+
+    if (core_window)
+    {
+        bd->CoreWindow->add_PointerMoved(Callback<WindowPointerMoved_Callback>(PointerMoved).Get(), &bd->PointerMovedToken);
+        bd->CoreWindow->add_PointerExited(Callback<WindowPointerExited_Callback>(PointerExited).Get(), &bd->PointerExitedToken);
+        bd->CoreWindow->add_PointerWheelChanged(Callback<WindowPointerWheelChanged_Callback>(PointerWheelChanged).Get(), &bd->PointerWheelChangedToken);
+        bd->CoreWindow->add_PointerPressed(Callback<WindowPointerPressed_Callback>(PointerPressed).Get(), &bd->PointerPressedToken);
+        bd->CoreWindow->add_PointerReleased(Callback<WindowPointerReleased_Callback>(PointerReleased).Get(), &bd->PointerReleasedToken);
+        bd->CoreWindow->add_KeyDown(Callback<WindowKeyDown_Callback>(KeyDown).Get(), &bd->KeyDownToken);
+        bd->CoreWindow->add_KeyUp(Callback<WindowKeyDown_Callback>(KeyUp).Get(), &bd->KeyUpToken);
+        bd->CoreWindow->add_CharacterReceived(Callback<WindowCharacterReceived_Callback>(CharacterReceived).Get(), &bd->CharacterReceivedToken);
+        bd->CoreWindow->add_Activated(Callback<WindowActivated_Callback>(WindowActivated).Get(), &bd->WindowActivatedToken);
+    }
+    else if (swapchain_panel)
+    {
+        ComPtr<ABI::Windows::UI::Core::ICoreInputSourceBase> controlInput;
+
+        auto winUI = LoadLibraryW(L"Windows.UI.dll");
+        auto SystemCreateControlInput = (PFN_CreateControlInput)GetProcAddress(winUI, "CreateControlInput");
+
+        HRESULT result = SystemCreateControlInput(ABI::Windows::UI::Core::IID_ICoreInputSourceBase, &controlInput);
+        if (SUCCEEDED(result))
+        {
+			controlInput->put_IsInputEnabled(true);
+
+			ComPtr<ISystemCoreInputInterop> coreInputInterop;
+            if (SUCCEEDED(controlInput.As(&coreInputInterop)))
+            {
+				ComPtr<ABI::Windows::UI::Xaml::Hosting::IElementCompositionPreviewStatics> elementCompositionPreviewStatics;
+				result = Windows::Foundation::GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Xaml_Hosting_ElementCompositionPreview).Get(), &elementCompositionPreviewStatics);
+
+                if (SUCCEEDED(result))
+                {
+                    ComPtr<ABI::Windows::UI::Xaml::IUIElement> uiElement;
+                    swapchain_panel->QueryInterface(uiElement.GetAddressOf());
+
+					ComPtr<ABI::Windows::UI::Composition::IVisual> visual;
+					elementCompositionPreviewStatics->GetElementVisual(uiElement.Get(), visual.GetAddressOf());
+
+					result = coreInputInterop->SetInputSource(visual.Get());
+
+                    if
+                    (
+                        SUCCEEDED(result)
+                        && SUCCEEDED(controlInput->QueryInterface(&bd->PointerInputSource))
+                        && SUCCEEDED(controlInput->QueryInterface(&bd->KeyboardInputSource))
+                    )
+                    {
+                        bd->PointerInputSource->add_PointerMoved(Callback<PointerMoved_Callback>(PointerMoved).Get(), &bd->PointerMovedToken);
+                        bd->PointerInputSource->add_PointerExited(Callback<PointerExited_Callback>(PointerExited).Get(), &bd->PointerExitedToken);
+                        bd->PointerInputSource->add_PointerWheelChanged(Callback<PointerWheelChanged_Callback>(PointerWheelChanged).Get(), &bd->PointerWheelChangedToken);
+                        bd->PointerInputSource->add_PointerPressed(Callback<PointerPressed_Callback>(PointerPressed).Get(), &bd->PointerPressedToken);
+                        bd->PointerInputSource->add_PointerReleased(Callback<PointerReleased_Callback>(PointerReleased).Get(), &bd->PointerReleasedToken);
+
+                        //bd->KeyboardInputSource->add_KeyDown(Callback<KeyDown_Callback>(KeyDown).Get(), &bd->KeyDownToken);
+                        //bd->KeyboardInputSource->add_KeyUp(Callback<KeyDown_Callback>(KeyUp).Get(), &bd->KeyUpToken);
+                        //bd->KeyboardInputSource->add_CharacterReceived(Callback<CharacterReceived_Callback>(CharacterReceived).Get(), &bd->CharacterReceivedToken);
+
+                        ComPtr<ABI::Windows::UI::Core::ICoreWindow> window = ImGui_ImplUwp_GetCoreWindowForCurrentThread();
+                        if (window.Get())
+                        {
+                            window->add_KeyDown(Callback<WindowKeyDown_Callback>(KeyDown).Get(), &bd->KeyDownToken);
+                            window->add_KeyUp(Callback<WindowKeyDown_Callback>(KeyUp).Get(), &bd->KeyUpToken);
+                            window->add_CharacterReceived(Callback<WindowCharacterReceived_Callback>(CharacterReceived).Get(), &bd->CharacterReceivedToken);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+IMGUI_IMPL_API bool ImGui_ImplUwp_Init(void* core_window)
+{
+    return ImGui_ImplUwp_InitEx((ABI::Windows::UI::Core::ICoreWindow*)core_window, nullptr, false);
+}
+
+IMGUI_IMPL_API bool ImGui_ImplUwp_InitForCurrentView()
+{
+    auto window = ImGui_ImplUwp_GetCoreWindowForCurrentThread();
+	if (!window)
+		return false;
+
+    return ImGui_ImplUwp_InitEx(window, nullptr, true);
+}
+
+IMGUI_IMPL_API bool ImGui_ImplUwp_InitForSwapChainPanel(void* swapchain_panel)
+{
+    return ImGui_ImplUwp_InitEx(nullptr, (ABI::Windows::UI::Xaml::Controls::ISwapChainPanel*)swapchain_panel, false);
+}
+
+void ImGui_ImplUwp_Shutdown()
+{
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+    IM_ASSERT(bd != nullptr && "No platform backend to shutdown, or already shutdown?");
+    ImGuiIO& io = ImGui::GetIO();
+
+    // Unload XInput library
+#ifndef IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+    if (bd->XInputDLL)
+        ::FreeLibrary(bd->XInputDLL);
+#endif // IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+
+    io.BackendPlatformName = nullptr;
+    io.BackendPlatformUserData = nullptr;
+    io.BackendFlags &= ~(ImGuiBackendFlags_HasMouseCursors | ImGuiBackendFlags_HasSetMousePos | ImGuiBackendFlags_HasGamepad);
+
+    if (bd->CoreWindow)
+    {
+        bd->CoreWindow->Release();
+
+        bd->CoreWindow->remove_PointerMoved(bd->PointerMovedToken);
+        bd->CoreWindow->remove_PointerExited(bd->PointerExitedToken);
+        bd->CoreWindow->remove_KeyDown(bd->KeyDownToken);
+        bd->CoreWindow->remove_KeyUp(bd->KeyUpToken);
+        bd->CoreWindow->remove_CharacterReceived(bd->CharacterReceivedToken);
+        bd->CoreWindow->remove_PointerWheelChanged(bd->PointerWheelChangedToken);
+        bd->CoreWindow->remove_Activated(bd->WindowActivatedToken);
+        bd->CoreWindow->remove_PointerPressed(bd->PointerPressedToken);
+        bd->CoreWindow->remove_PointerReleased(bd->PointerReleasedToken);
+    }
+	else if (bd->SwapChainPanel)
+	{
+		bd->PointerInputSource->remove_PointerMoved(bd->PointerMovedToken);
+		bd->PointerInputSource->remove_PointerExited(bd->PointerExitedToken);
+		bd->PointerInputSource->remove_PointerWheelChanged(bd->PointerWheelChangedToken);
+		bd->PointerInputSource->remove_PointerPressed(bd->PointerPressedToken);
+		bd->PointerInputSource->remove_PointerReleased(bd->PointerReleasedToken);
+
+		//bd->KeyboardInputSource->remove_KeyDown(bd->KeyDownToken);
+		//bd->KeyboardInputSource->remove_KeyUp(bd->KeyUpToken);
+		//bd->KeyboardInputSource->remove_CharacterReceived(bd->CharacterReceivedToken);
+
+        ComPtr<ABI::Windows::UI::Core::ICoreWindow> window = ImGui_ImplUwp_GetCoreWindowForCurrentThread();
+        if (window.Get())
+        {
+            window->remove_KeyDown(bd->KeyDownToken);
+            window->remove_KeyUp(bd->KeyUpToken);
+            window->remove_CharacterReceived(bd->CharacterReceivedToken);
+        }
+
+		bd->PointerInputSource->Release();
+		bd->KeyboardInputSource->Release();
+		bd->SwapChainPanel->Release();
+		bd->SwapChainPanelElement->Release();
+	}
+
+    IM_DELETE(bd);
+}
+
+static bool ImGui_ImplUwp_UpdateMouseCursor()
+{
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange)
+        return false;
+
+    ImGuiMouseCursor imgui_cursor = ImGui::GetMouseCursor();
+    if (imgui_cursor == ImGuiMouseCursor_None || io.MouseDrawCursor)
+    {
+        // Hide OS mouse cursor if imgui is drawing it or if it wants no cursor
+        if (bd->CoreWindow)
+            bd->CoreWindow->put_PointerCursor(nullptr);
+        else if (bd->PointerInputSource)
+			bd->PointerInputSource->put_PointerCursor(nullptr);
+    }
+    else
+    {
+        // Show OS mouse cursor
+        ComPtr<ABI::Windows::UI::Core::ICoreCursor> cursor;
+        ComPtr<ABI::Windows::UI::Core::ICoreCursorFactory> cursorFactory;
+        Windows::Foundation::GetActivationFactory(HStringReference(RuntimeClass_Windows_UI_Core_CoreCursor).Get(), &cursorFactory);
+
+        HRESULT result = 0;
+
+        switch (imgui_cursor)
+        {
+        case ImGuiMouseCursor_Arrow:        result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_Arrow, 0, &cursor); break;
+        case ImGuiMouseCursor_TextInput:    result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_IBeam, 0, &cursor); break;
+        case ImGuiMouseCursor_ResizeAll:    result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_SizeAll, 0, &cursor); break;
+        case ImGuiMouseCursor_ResizeEW:     result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_SizeWestEast, 0, &cursor); break;
+        case ImGuiMouseCursor_ResizeNS:     result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_SizeNorthSouth, 0, &cursor); break;
+        case ImGuiMouseCursor_ResizeNESW:   result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_SizeNortheastSouthwest, 0, &cursor); break;
+        case ImGuiMouseCursor_ResizeNWSE:   result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_SizeNorthwestSoutheast, 0, &cursor); break;
+        case ImGuiMouseCursor_Hand:         result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_Hand, 0, &cursor); break;
+        case ImGuiMouseCursor_NotAllowed:   result = cursorFactory->CreateCursor(ABI::Windows::UI::Core::CoreCursorType_UniversalNo, 0, &cursor); break;
+        }
+
+        if (result == S_OK)
+        {
+			if (bd->CoreWindow)
+                bd->CoreWindow->put_PointerCursor(cursor.Get());
+			else if (bd->PointerInputSource)
+				bd->PointerInputSource->put_PointerCursor(cursor.Get());
+        }
+    }
+    return true;
+}
+
+static bool IsVkDown(int vk)
+{
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+
+    ABI::Windows::UI::Core::CoreVirtualKeyStates states = ABI::Windows::UI::Core::CoreVirtualKeyStates::CoreVirtualKeyStates_None;
+
+	if (bd->CoreWindow)
+        bd->CoreWindow->GetKeyState((ABI::Windows::System::VirtualKey)vk, &states);
+	else if (bd->KeyboardInputSource)
+		bd->KeyboardInputSource->GetCurrentKeyState((ABI::Windows::System::VirtualKey)vk, &states);
+
+    return (states & ABI::Windows::UI::Core::CoreVirtualKeyStates::CoreVirtualKeyStates_Down) != 0;
+}
+
+static void ImGui_ImplUwp_AddKeyEvent(ImGuiKey key, bool down, int native_keycode, int native_scancode = -1)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddKeyEvent(key, down);
+    io.SetKeyEventNativeData(key, native_keycode, native_scancode); // To support legacy indexing (<1.87 user code)
+    IM_UNUSED(native_scancode);
+}
+
+static void ImGui_ImplUwp_ProcessKeyEventsWorkarounds()
+{
+    // Left & right Shift keys: when both are pressed together, Windows tend to not generate the WM_KEYUP event for the first released one.
+    if (ImGui::IsKeyDown(ImGuiKey_LeftShift) && !IsVkDown(VK_LSHIFT))
+        ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftShift, false, VK_LSHIFT);
+    if (ImGui::IsKeyDown(ImGuiKey_RightShift) && !IsVkDown(VK_RSHIFT))
+        ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightShift, false, VK_RSHIFT);
+
+    // Sometimes WM_KEYUP for Win key is not passed down to the app (e.g. for Win+V on some setups, according to GLFW).
+    if (ImGui::IsKeyDown(ImGuiKey_LeftSuper) && !IsVkDown(VK_LWIN))
+        ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftSuper, false, VK_LWIN);
+    if (ImGui::IsKeyDown(ImGuiKey_RightSuper) && !IsVkDown(VK_RWIN))
+        ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightSuper, false, VK_RWIN);
+}
+
+static void ImGui_ImplUwp_UpdateKeyModifiers()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddKeyEvent(ImGuiMod_Ctrl, IsVkDown(VK_CONTROL));
+    io.AddKeyEvent(ImGuiMod_Shift, IsVkDown(VK_SHIFT));
+    io.AddKeyEvent(ImGuiMod_Alt, IsVkDown(VK_MENU));
+    io.AddKeyEvent(ImGuiMod_Super, IsVkDown(VK_APPS));
+}
+
+static void ImGui_ImplUwp_UpdateMouseData()
+{
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+    ImGuiIO& io = ImGui::GetIO();
+    //IM_ASSERT(bd->CoreWindow != 0);
+
+    if (bd->CoreWindow)
+    {
+        bool is_app_focused;
+
+        ComPtr<ABI::Windows::UI::Core::ICoreWindow5> coreWindow5;
+        HRESULT hr = bd->CoreWindow->QueryInterface(coreWindow5.GetAddressOf());
+
+        if (hr == S_OK)
+        {
+            ABI::Windows::UI::Core::CoreWindowActivationMode mode;
+            coreWindow5->get_ActivationMode(&mode);
+
+            is_app_focused = mode == ABI::Windows::UI::Core::CoreWindowActivationMode::CoreWindowActivationMode_ActivatedInForeground;
+        }
+        else
+        {
+            boolean inputEnabled;
+            boolean visible;
+
+            bd->CoreWindow->get_IsInputEnabled(&inputEnabled);
+            bd->CoreWindow->get_Visible(&visible);
+
+            is_app_focused = visible && inputEnabled;
+        }
+
+        if (is_app_focused)
+        {
+            // (Optional) Set OS mouse position from Dear ImGui if requested (rarely used, only when ImGuiConfigFlags_NavEnableSetMousePos is enabled by user)
+            if (io.WantSetMousePos)
+            {
+                ComPtr<ABI::Windows::UI::Core::ICoreWindow2> coreWindow2;
+                hr = bd->CoreWindow->QueryInterface(coreWindow2.GetAddressOf());
+
+                if (hr == S_OK)
+                {
+                    ABI::Windows::Foundation::Point pos = { (int)io.MousePos.x / io.DisplayFramebufferScale.x, (int)io.MousePos.y / io.DisplayFramebufferScale.y };
+                    coreWindow2->put_PointerPosition(pos);
+                }
+            }
+        }
+    }
+}
+
+// Gamepad navigation mapping
+static void ImGui_ImplUwp_UpdateGamepads()
+{
+#ifndef IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+    //if ((io.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad) == 0) // FIXME: Technically feeding gamepad shouldn't depend on this now that they are regular inputs.
+    //    return;
+
+    // Calling XInputGetState() every frame on disconnected gamepads is unfortunately too slow.
+    // Instead we refresh gamepad availability by calling XInputGetCapabilities() _only_ after receiving WM_DEVICECHANGE.
+    if (bd->WantUpdateHasGamepad)
+    {
+        XINPUT_CAPABILITIES caps = {};
+        bd->HasGamepad = bd->XInputGetCapabilities ? (bd->XInputGetCapabilities(0, XINPUT_FLAG_GAMEPAD, &caps) == ERROR_SUCCESS) : false;
+        bd->WantUpdateHasGamepad = false;
+    }
+
+    io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;
+    XINPUT_STATE xinput_state;
+    XINPUT_GAMEPAD& gamepad = xinput_state.Gamepad;
+    if (!bd->HasGamepad || bd->XInputGetState == nullptr || bd->XInputGetState(0, &xinput_state) != ERROR_SUCCESS)
+        return;
+    io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
+
+    #define IM_SATURATE(V)                      (V < 0.0f ? 0.0f : V > 1.0f ? 1.0f : V)
+    #define MAP_BUTTON(KEY_NO, BUTTON_ENUM)     { io.AddKeyEvent(KEY_NO, (gamepad.wButtons & BUTTON_ENUM) != 0); }
+    #define MAP_ANALOG(KEY_NO, VALUE, V0, V1)   { float vn = (float)(VALUE - V0) / (float)(V1 - V0); io.AddKeyAnalogEvent(KEY_NO, vn > 0.10f, IM_SATURATE(vn)); }
+    MAP_BUTTON(ImGuiKey_GamepadStart,           XINPUT_GAMEPAD_START);
+    MAP_BUTTON(ImGuiKey_GamepadBack,            XINPUT_GAMEPAD_BACK);
+    MAP_BUTTON(ImGuiKey_GamepadFaceLeft,        XINPUT_GAMEPAD_X);
+    MAP_BUTTON(ImGuiKey_GamepadFaceRight,       XINPUT_GAMEPAD_B);
+    MAP_BUTTON(ImGuiKey_GamepadFaceUp,          XINPUT_GAMEPAD_Y);
+    MAP_BUTTON(ImGuiKey_GamepadFaceDown,        XINPUT_GAMEPAD_A);
+    MAP_BUTTON(ImGuiKey_GamepadDpadLeft,        XINPUT_GAMEPAD_DPAD_LEFT);
+    MAP_BUTTON(ImGuiKey_GamepadDpadRight,       XINPUT_GAMEPAD_DPAD_RIGHT);
+    MAP_BUTTON(ImGuiKey_GamepadDpadUp,          XINPUT_GAMEPAD_DPAD_UP);
+    MAP_BUTTON(ImGuiKey_GamepadDpadDown,        XINPUT_GAMEPAD_DPAD_DOWN);
+    MAP_BUTTON(ImGuiKey_GamepadL1,              XINPUT_GAMEPAD_LEFT_SHOULDER);
+    MAP_BUTTON(ImGuiKey_GamepadR1,              XINPUT_GAMEPAD_RIGHT_SHOULDER);
+    MAP_ANALOG(ImGuiKey_GamepadL2,              gamepad.bLeftTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD, 255);
+    MAP_ANALOG(ImGuiKey_GamepadR2,              gamepad.bRightTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD, 255);
+    MAP_BUTTON(ImGuiKey_GamepadL3,              XINPUT_GAMEPAD_LEFT_THUMB);
+    MAP_BUTTON(ImGuiKey_GamepadR3,              XINPUT_GAMEPAD_RIGHT_THUMB);
+    MAP_ANALOG(ImGuiKey_GamepadLStickLeft,      gamepad.sThumbLX, -XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, -32768);
+    MAP_ANALOG(ImGuiKey_GamepadLStickRight,     gamepad.sThumbLX, +XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, +32767);
+    MAP_ANALOG(ImGuiKey_GamepadLStickUp,        gamepad.sThumbLY, +XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, +32767);
+    MAP_ANALOG(ImGuiKey_GamepadLStickDown,      gamepad.sThumbLY, -XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, -32768);
+    MAP_ANALOG(ImGuiKey_GamepadRStickLeft,      gamepad.sThumbRX, -XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, -32768);
+    MAP_ANALOG(ImGuiKey_GamepadRStickRight,     gamepad.sThumbRX, +XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, +32767);
+    MAP_ANALOG(ImGuiKey_GamepadRStickUp,        gamepad.sThumbRY, +XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, +32767);
+    MAP_ANALOG(ImGuiKey_GamepadRStickDown,      gamepad.sThumbRY, -XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE, -32768);
+    #undef MAP_BUTTON
+    #undef MAP_ANALOG
+#endif // #ifndef IMGUI_IMPL_UWP_DISABLE_GAMEPAD
+}
+
+void    ImGui_ImplUwp_NewFrame()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+    IM_ASSERT(bd != nullptr && "Did you call ImGui_ImplUwp_Init()?");
+
+    // Setup display size (every frame to accommodate for window resizing)
+
+    // XXX Xbox dimensions
+    io.DisplaySize = ImVec2(3840.0f, 2160.0f); // XXX
+
+	// if (bd->CoreWindow)
+	// {
+	// 	ABI::Windows::Foundation::Rect rect = { 0, 0, 0, 0 };
+	// 	bd->CoreWindow->get_Bounds(&rect);
+	// 	io.DisplaySize = ImVec2(rect.Width * io.DisplayFramebufferScale.x, rect.Height * io.DisplayFramebufferScale.y);
+	// }
+	// else if (bd->SwapChainPanelElement)
+	// {
+    //     DOUBLE w, h;
+	// 	bd->SwapChainPanelElement->get_ActualHeight(&h);
+	// 	bd->SwapChainPanelElement->get_ActualWidth(&w);
+	// 	io.DisplaySize = ImVec2(w * io.DisplayFramebufferScale.x, h * io.DisplayFramebufferScale.y);
+	// }
+
+    // Setup time step
+    INT64 current_time = 0;
+    ::QueryPerformanceCounter((LARGE_INTEGER*)&current_time);
+    io.DeltaTime = (float)(current_time - bd->Time) / bd->TicksPerSecond;
+    bd->Time = current_time;
+
+    // Update OS mouse position
+    ImGui_ImplUwp_UpdateMouseData();
+
+    // Process workarounds for known Windows key handling issues
+    ImGui_ImplUwp_ProcessKeyEventsWorkarounds();
+
+    // Update OS mouse cursor with the cursor requested by imgui
+    ImGuiMouseCursor mouse_cursor = io.MouseDrawCursor ? ImGuiMouseCursor_None : ImGui::GetMouseCursor();
+    if (bd->LastMouseCursor != mouse_cursor)
+    {
+        bd->LastMouseCursor = mouse_cursor;
+        ImGui_ImplUwp_UpdateMouseCursor();
+    }
+
+    // Update game controllers (if enabled and available)
+    ImGui_ImplUwp_UpdateGamepads();
+}
+
+// There is no distinct VK_xxx for keypad enter, instead it is VK_RETURN + KF_EXTENDED, we assign it an arbitrary value to make code more readable (VK_ codes go up to 255)
+#define IM_VK_KEYPAD_ENTER      (VK_RETURN + 256)
+
+// Map VK_xxx to ImGuiKey_xxx.
+static ImGuiKey ImGui_ImplUwp_VirtualKeyToImGuiKey(WPARAM wParam)
+{
+    switch (wParam)
+    {
+        case VK_TAB: return ImGuiKey_Tab;
+        case VK_LEFT: return ImGuiKey_LeftArrow;
+        case VK_RIGHT: return ImGuiKey_RightArrow;
+        case VK_UP: return ImGuiKey_UpArrow;
+        case VK_DOWN: return ImGuiKey_DownArrow;
+        case VK_PRIOR: return ImGuiKey_PageUp;
+        case VK_NEXT: return ImGuiKey_PageDown;
+        case VK_HOME: return ImGuiKey_Home;
+        case VK_END: return ImGuiKey_End;
+        case VK_INSERT: return ImGuiKey_Insert;
+        case VK_DELETE: return ImGuiKey_Delete;
+        case VK_BACK: return ImGuiKey_Backspace;
+        case VK_SPACE: return ImGuiKey_Space;
+        case VK_RETURN: return ImGuiKey_Enter;
+        case VK_ESCAPE: return ImGuiKey_Escape;
+        case VK_OEM_7: return ImGuiKey_Apostrophe;
+        case VK_OEM_COMMA: return ImGuiKey_Comma;
+        case VK_OEM_MINUS: return ImGuiKey_Minus;
+        case VK_OEM_PERIOD: return ImGuiKey_Period;
+        case VK_OEM_2: return ImGuiKey_Slash;
+        case VK_OEM_1: return ImGuiKey_Semicolon;
+        case VK_OEM_PLUS: return ImGuiKey_Equal;
+        case VK_OEM_4: return ImGuiKey_LeftBracket;
+        case VK_OEM_5: return ImGuiKey_Backslash;
+        case VK_OEM_6: return ImGuiKey_RightBracket;
+        case VK_OEM_3: return ImGuiKey_GraveAccent;
+        case VK_CAPITAL: return ImGuiKey_CapsLock;
+        case VK_SCROLL: return ImGuiKey_ScrollLock;
+        case VK_NUMLOCK: return ImGuiKey_NumLock;
+        case VK_SNAPSHOT: return ImGuiKey_PrintScreen;
+        case VK_PAUSE: return ImGuiKey_Pause;
+        case VK_NUMPAD0: return ImGuiKey_Keypad0;
+        case VK_NUMPAD1: return ImGuiKey_Keypad1;
+        case VK_NUMPAD2: return ImGuiKey_Keypad2;
+        case VK_NUMPAD3: return ImGuiKey_Keypad3;
+        case VK_NUMPAD4: return ImGuiKey_Keypad4;
+        case VK_NUMPAD5: return ImGuiKey_Keypad5;
+        case VK_NUMPAD6: return ImGuiKey_Keypad6;
+        case VK_NUMPAD7: return ImGuiKey_Keypad7;
+        case VK_NUMPAD8: return ImGuiKey_Keypad8;
+        case VK_NUMPAD9: return ImGuiKey_Keypad9;
+        case VK_DECIMAL: return ImGuiKey_KeypadDecimal;
+        case VK_DIVIDE: return ImGuiKey_KeypadDivide;
+        case VK_MULTIPLY: return ImGuiKey_KeypadMultiply;
+        case VK_SUBTRACT: return ImGuiKey_KeypadSubtract;
+        case VK_ADD: return ImGuiKey_KeypadAdd;
+        case IM_VK_KEYPAD_ENTER: return ImGuiKey_KeypadEnter;
+        case VK_LSHIFT: return ImGuiKey_LeftShift;
+        case VK_LCONTROL: return ImGuiKey_LeftCtrl;
+        case VK_LMENU: return ImGuiKey_LeftAlt;
+        case VK_LWIN: return ImGuiKey_LeftSuper;
+        case VK_RSHIFT: return ImGuiKey_RightShift;
+        case VK_RCONTROL: return ImGuiKey_RightCtrl;
+        case VK_RMENU: return ImGuiKey_RightAlt;
+        case VK_RWIN: return ImGuiKey_RightSuper;
+        case VK_APPS: return ImGuiKey_Menu;
+        case '0': return ImGuiKey_0;
+        case '1': return ImGuiKey_1;
+        case '2': return ImGuiKey_2;
+        case '3': return ImGuiKey_3;
+        case '4': return ImGuiKey_4;
+        case '5': return ImGuiKey_5;
+        case '6': return ImGuiKey_6;
+        case '7': return ImGuiKey_7;
+        case '8': return ImGuiKey_8;
+        case '9': return ImGuiKey_9;
+        case 'A': return ImGuiKey_A;
+        case 'B': return ImGuiKey_B;
+        case 'C': return ImGuiKey_C;
+        case 'D': return ImGuiKey_D;
+        case 'E': return ImGuiKey_E;
+        case 'F': return ImGuiKey_F;
+        case 'G': return ImGuiKey_G;
+        case 'H': return ImGuiKey_H;
+        case 'I': return ImGuiKey_I;
+        case 'J': return ImGuiKey_J;
+        case 'K': return ImGuiKey_K;
+        case 'L': return ImGuiKey_L;
+        case 'M': return ImGuiKey_M;
+        case 'N': return ImGuiKey_N;
+        case 'O': return ImGuiKey_O;
+        case 'P': return ImGuiKey_P;
+        case 'Q': return ImGuiKey_Q;
+        case 'R': return ImGuiKey_R;
+        case 'S': return ImGuiKey_S;
+        case 'T': return ImGuiKey_T;
+        case 'U': return ImGuiKey_U;
+        case 'V': return ImGuiKey_V;
+        case 'W': return ImGuiKey_W;
+        case 'X': return ImGuiKey_X;
+        case 'Y': return ImGuiKey_Y;
+        case 'Z': return ImGuiKey_Z;
+        case VK_F1: return ImGuiKey_F1;
+        case VK_F2: return ImGuiKey_F2;
+        case VK_F3: return ImGuiKey_F3;
+        case VK_F4: return ImGuiKey_F4;
+        case VK_F5: return ImGuiKey_F5;
+        case VK_F6: return ImGuiKey_F6;
+        case VK_F7: return ImGuiKey_F7;
+        case VK_F8: return ImGuiKey_F8;
+        case VK_F9: return ImGuiKey_F9;
+        case VK_F10: return ImGuiKey_F10;
+        case VK_F11: return ImGuiKey_F11;
+        case VK_F12: return ImGuiKey_F12;
+        default: return ImGuiKey_None;
+    }
+}
+
+static ImGuiMouseSource GetMouseSourceFromDevice(ABI::Windows::Devices::Input::IPointerDevice* device)
+{
+    ABI::Windows::Devices::Input::PointerDeviceType type;
+    device->get_PointerDeviceType(&type);
+
+    if (type == ABI::Windows::Devices::Input::PointerDeviceType::PointerDeviceType_Pen)
+        return ImGuiMouseSource_Pen;
+    if (type == ABI::Windows::Devices::Input::PointerDeviceType::PointerDeviceType_Touch)
+        return ImGuiMouseSource_TouchScreen;
+    return ImGuiMouseSource_Mouse;
+}
+
+int PointerMoved(::IInspectable* sender, ABI::Windows::UI::Core::IPointerEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    ABI::Windows::Foundation::Point point;
+    ComPtr<ABI::Windows::UI::Input::IPointerPoint> pointerPoint;
+    ComPtr<ABI::Windows::Devices::Input::IPointerDevice> pointerDevice;
+
+    if (args->get_CurrentPoint(&pointerPoint) != S_OK)
+        return 0;
+
+    if (pointerPoint->get_PointerDevice(&pointerDevice) != S_OK)
+        return 0;
+
+    pointerPoint->get_Position(&point);
+
+    ImGuiMouseSource mouse_source = GetMouseSourceFromDevice(pointerDevice.Get());
+    io.AddMouseSourceEvent(mouse_source);
+    io.AddMousePosEvent(point.X * io.DisplayFramebufferScale.x, point.Y * io.DisplayFramebufferScale.y);
+
+    return 0;
+}
+
+int PointerExited(::IInspectable* sender, ABI::Windows::UI::Core::IPointerEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+
+    bd->MouseTrackedArea = 0;
+    io.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
+
+    return 0;
+}
+
+int KeyDown(::IInspectable* sender, ABI::Windows::UI::Core::IKeyEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    ABI::Windows::System::VirtualKey key;
+    ABI::Windows::UI::Core::CorePhysicalKeyStatus keyStatus;
+    args->get_VirtualKey(&key);
+    args->get_KeyStatus(&keyStatus);
+
+    const bool is_key_down = true;
+    if (key < 256)
+    {
+        // Submit modifiers
+        ImGui_ImplUwp_UpdateKeyModifiers();
+
+        int vk = (int)key;
+        if ((key == VK_RETURN) && keyStatus.IsExtendedKey)
+            vk = IM_VK_KEYPAD_ENTER;
+
+        // Submit key event
+        const ImGuiKey key = ImGui_ImplUwp_VirtualKeyToImGuiKey(vk);
+        const int scancode = keyStatus.ScanCode;
+        if (key != ImGuiKey_None)
+            ImGui_ImplUwp_AddKeyEvent(key, is_key_down, vk, scancode);
+
+        // Submit individual left/right modifier events
+        if (vk == VK_SHIFT)
+        {
+            // Important: Shift keys tend to get stuck when pressed together, missing key-up events are corrected in ImGui_ImplUwp_ProcessKeyEventsWorkarounds()
+            if (IsVkDown(VK_LSHIFT) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftShift, is_key_down, VK_LSHIFT, scancode); }
+            if (IsVkDown(VK_RSHIFT) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightShift, is_key_down, VK_RSHIFT, scancode); }
+        }
+        else if (vk == VK_CONTROL)
+        {
+            if (IsVkDown(VK_LCONTROL) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftCtrl, is_key_down, VK_LCONTROL, scancode); }
+            if (IsVkDown(VK_RCONTROL) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightCtrl, is_key_down, VK_RCONTROL, scancode); }
+        }
+        else if (vk == VK_MENU || keyStatus.IsMenuKeyDown)
+        {
+            if (IsVkDown(VK_LMENU) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftAlt, is_key_down, VK_LMENU, scancode); }
+            if (IsVkDown(VK_RMENU) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightAlt, is_key_down, VK_RMENU, scancode); }
+
+            if (!IsVkDown(VK_LMENU) && !IsVkDown(VK_RMENU)) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftAlt, is_key_down, VK_LMENU, scancode); }
+        }
+    }
+
+    return 0;
+}
+
+int KeyUp(::IInspectable* sender, ABI::Windows::UI::Core::IKeyEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    ABI::Windows::System::VirtualKey key;
+    ABI::Windows::UI::Core::CorePhysicalKeyStatus keyStatus;
+    args->get_VirtualKey(&key);
+    args->get_KeyStatus(&keyStatus);
+
+    const bool is_key_down = false;
+    if (key < 256)
+    {
+        // Submit modifiers
+        ImGui_ImplUwp_UpdateKeyModifiers();
+
+        int vk = (int)key;
+        if ((key == VK_RETURN) && keyStatus.IsExtendedKey)
+            vk = IM_VK_KEYPAD_ENTER;
+
+        // Submit key event
+        const ImGuiKey key = ImGui_ImplUwp_VirtualKeyToImGuiKey(vk);
+        const int scancode = keyStatus.ScanCode;
+        if (key != ImGuiKey_None)
+            ImGui_ImplUwp_AddKeyEvent(key, is_key_down, vk, scancode);
+
+        // Submit individual left/right modifier events
+        if (vk == VK_SHIFT)
+        {
+            // Important: Shift keys tend to get stuck when pressed together, missing key-up events are corrected in ImGui_ImplUwp_ProcessKeyEventsWorkarounds()
+            if (IsVkDown(VK_LSHIFT) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftShift, is_key_down, VK_LSHIFT, scancode); }
+            if (IsVkDown(VK_RSHIFT) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightShift, is_key_down, VK_RSHIFT, scancode); }
+        }
+        else if (vk == VK_CONTROL)
+        {
+            if (IsVkDown(VK_LCONTROL) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftCtrl, is_key_down, VK_LCONTROL, scancode); }
+            if (IsVkDown(VK_RCONTROL) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightCtrl, is_key_down, VK_RCONTROL, scancode); }
+        }
+        else if (vk == VK_MENU || !keyStatus.IsMenuKeyDown)
+        {
+            if (IsVkDown(VK_LMENU) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftAlt, is_key_down, VK_LMENU, scancode); }
+            if (IsVkDown(VK_RMENU) == is_key_down) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_RightAlt, is_key_down, VK_RMENU, scancode); }
+
+            if (!IsVkDown(VK_LMENU) && !IsVkDown(VK_RMENU)) { ImGui_ImplUwp_AddKeyEvent(ImGuiKey_LeftAlt, is_key_down, VK_LMENU, scancode); }
+        }
+    }
+
+    return 0;
+}
+
+unsigned short UTF32ToUTF16(UINT32 utf32)
+{
+    unsigned int h, l;
+
+    if (utf32 < 0x10000)
+    {
+        h = 0;
+        l = utf32;
+        return utf32;
+    }
+    unsigned int t = utf32 - 0x10000;
+    h = (((t << 12) >> 22) + 0xD800);
+    l = (((t << 22) >> 22) + 0xDC00);
+    unsigned short ret = ((h << 16) | (l & 0x0000FFFF));
+    return ret;
+}
+
+int CharacterReceived(::IInspectable* sender, ABI::Windows::UI::Core::ICharacterReceivedEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    UINT32 code;
+    args->get_KeyCode(&code);
+
+    io.AddInputCharacterUTF16(UTF32ToUTF16(code));
+
+    return 0;
+}
+
+int PointerWheelChanged(::IInspectable* sender, ABI::Windows::UI::Core::IPointerEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    INT32 mouseWheelDelta;
+    boolean isHorizontalMouseWheel;
+    ComPtr<ABI::Windows::UI::Input::IPointerPoint> pointerPoint;
+    ComPtr<ABI::Windows::UI::Input::IPointerPointProperties> pointerPointProps;
+
+    if (args->get_CurrentPoint(&pointerPoint) != S_OK)
+        return 0;
+
+    if (pointerPoint->get_Properties(&pointerPointProps) != S_OK)
+        return 0;
+
+    pointerPointProps->get_IsHorizontalMouseWheel(&isHorizontalMouseWheel);
+    pointerPointProps->get_MouseWheelDelta(&mouseWheelDelta);
+
+    if (isHorizontalMouseWheel)
+        io.AddMouseWheelEvent(-(float) mouseWheelDelta / (float)WHEEL_DELTA, 0.0f);
+    else
+        io.AddMouseWheelEvent(0.0f, (float)mouseWheelDelta / (float)WHEEL_DELTA);
+
+    return 0;
+}
+
+int WindowActivated(ABI::Windows::UI::Core::ICoreWindow* sender, ABI::Windows::UI::Core::IWindowActivatedEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+
+    ABI::Windows::UI::Core::CoreWindowActivationState state;
+    args->get_WindowActivationState(&state);
+
+    io.AddFocusEvent(state != ABI::Windows::UI::Core::CoreWindowActivationState::CoreWindowActivationState_Deactivated);
+
+    return 0;
+}
+
+int PointerPressed(::IInspectable* sender, ABI::Windows::UI::Core::IPointerEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+
+    ComPtr<ABI::Windows::UI::Input::IPointerPoint> pointerPoint;
+    ComPtr<ABI::Windows::Devices::Input::IPointerDevice> pointerDevice;
+    ComPtr<ABI::Windows::UI::Input::IPointerPointProperties> pointerPointProps;
+
+    boolean lBtn;
+    boolean rBtn;
+    boolean mBtn;
+    boolean x1Btn;
+    boolean x2Btn;
+
+    if (args->get_CurrentPoint(&pointerPoint) != S_OK)
+        return 0;
+
+    if (pointerPoint->get_Properties(&pointerPointProps) != S_OK)
+        return 0;
+
+    if (pointerPoint->get_PointerDevice(&pointerDevice) != S_OK)
+        return 0;
+
+    pointerPointProps->get_IsLeftButtonPressed(&lBtn);
+    pointerPointProps->get_IsRightButtonPressed(&rBtn);
+    pointerPointProps->get_IsMiddleButtonPressed(&mBtn);
+    pointerPointProps->get_IsXButton1Pressed(&x1Btn);
+    pointerPointProps->get_IsXButton2Pressed(&x2Btn);
+
+    int button = 0;
+
+    if (x2Btn && (bd->MouseButtonsDown & (1 << 4)) == 0) button = 4;
+    if (x1Btn && (bd->MouseButtonsDown & (1 << 3)) == 0) button = 3;
+    if (mBtn && (bd->MouseButtonsDown & (1 << 2)) == 0) button = 2;
+    if (rBtn && (bd->MouseButtonsDown & (1 << 1)) == 0) button = 1;
+    if (lBtn && (bd->MouseButtonsDown & (1 << 0)) == 0) button = 0;
+
+    ImGuiMouseSource mouse_source = GetMouseSourceFromDevice(pointerDevice.Get());
+
+    bd->MouseButtonsDown |= 1 << button;
+    io.AddMouseSourceEvent(mouse_source);
+    io.AddMouseButtonEvent(button, true);
+
+    return 0;
+}
+
+int PointerReleased(::IInspectable* sender, ABI::Windows::UI::Core::IPointerEventArgs* args)
+{
+    if (ImGui::GetCurrentContext() == nullptr)
+        return 0;
+
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplUwp_Data* bd = ImGui_ImplUwp_GetBackendData();
+
+    ComPtr<ABI::Windows::UI::Input::IPointerPoint> pointerPoint;
+    ComPtr<ABI::Windows::Devices::Input::IPointerDevice> pointerDevice;
+    ComPtr<ABI::Windows::UI::Input::IPointerPointProperties> pointerPointProps;
+
+    boolean lBtn;
+    boolean rBtn;
+    boolean mBtn;
+    boolean x1Btn;
+    boolean x2Btn;
+
+    if (args->get_CurrentPoint(&pointerPoint) != S_OK)
+        return 0;
+
+    if (pointerPoint->get_Properties(&pointerPointProps) != S_OK)
+        return 0;
+
+    if (pointerPoint->get_PointerDevice(&pointerDevice) != S_OK)
+        return 0;
+
+    pointerPointProps->get_IsLeftButtonPressed(&lBtn);
+    pointerPointProps->get_IsRightButtonPressed(&rBtn);
+    pointerPointProps->get_IsMiddleButtonPressed(&mBtn);
+    pointerPointProps->get_IsXButton1Pressed(&x1Btn);
+    pointerPointProps->get_IsXButton2Pressed(&x2Btn);
+
+    int button = 0;
+
+    if (!x2Btn && (bd->MouseButtonsDown & (1 << 4)) != 0) button = 4;
+    if (!x1Btn && (bd->MouseButtonsDown & (1 << 3)) != 0) button = 3;
+    if (!mBtn && (bd->MouseButtonsDown & (1 << 2)) != 0) button = 2;
+    if (!rBtn && (bd->MouseButtonsDown & (1 << 1)) != 0) button = 1;
+    if (!lBtn && (bd->MouseButtonsDown & (1 << 0)) != 0) button = 0;
+
+    ImGuiMouseSource mouse_source = GetMouseSourceFromDevice(pointerDevice.Get());
+
+    bd->MouseButtonsDown &= ~(1 << button);
+    io.AddMouseSourceEvent(mouse_source);
+    io.AddMouseButtonEvent(button, false);
+
+    return 0;
+}
+
+// UWP clipboard implementation
+#if !defined(IMGUI_DISABLE_UWP_DEFAULT_CLIPBOARD_FUNCTIONS)
+static const char* ImGui_ImplUwp_GetClipboardTextFn(void* user_data_ctx)
+{
+    ImGuiContext& g = *(ImGuiContext*)user_data_ctx;
+    g.ClipboardHandlerData.clear();
+
+    Microsoft::WRL::ComPtr<ABI::Windows::ApplicationModel::DataTransfer::IClipboardStatics> clipboardStatics;
+    Microsoft::WRL::ComPtr<ABI::Windows::ApplicationModel::DataTransfer::IStandardDataFormatsStatics> standardDataFormats;
+    Microsoft::WRL::ComPtr<ABI::Windows::ApplicationModel::DataTransfer::IDataPackageView> dataPkgView;
+    Windows::Foundation::GetActivationFactory(Microsoft::WRL::Wrappers::HStringReference(RuntimeClass_Windows_ApplicationModel_DataTransfer_Clipboard).Get(), &clipboardStatics);
+    Windows::Foundation::GetActivationFactory(Microsoft::WRL::Wrappers::HStringReference(RuntimeClass_Windows_ApplicationModel_DataTransfer_StandardDataFormats).Get(), &standardDataFormats);
+
+    if (clipboardStatics->GetContent(&dataPkgView) != S_OK)
+        return NULL;
+
+    Microsoft::WRL::Wrappers::HString hstr;
+    boolean containsText;
+    standardDataFormats->get_Text(hstr.GetAddressOf());
+    dataPkgView->Contains(hstr.Get(), &containsText);
+    hstr.Release();
+
+    if (!containsText)
+        return NULL;
+
+    Microsoft::WRL::Wrappers::HString text;
+    Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperation<HSTRING>> operation;
+
+    if (dataPkgView->GetTextAsync(operation.GetAddressOf()) != S_OK)
+        return NULL;
+
+    HRESULT hr;
+    Microsoft::WRL::Wrappers::Event opCompleted(CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, WRITE_OWNER | EVENT_ALL_ACCESS));
+
+    Microsoft::WRL::ComPtr<ABI::Windows::Foundation::IAsyncOperationCompletedHandler<HSTRING>> cb
+        = Microsoft::WRL::Callback<Microsoft::WRL::Implements<Microsoft::WRL::RuntimeClassFlags<Microsoft::WRL::ClassicCom>, ABI::Windows::Foundation::IAsyncOperationCompletedHandler<HSTRING>, Microsoft::WRL::FtmBase>>(
+            [&opCompleted](ABI::Windows::Foundation::IAsyncOperation<HSTRING>* asyncOperation, AsyncStatus status)->HRESULT
+            {
+                SetEvent(opCompleted.Get());
+                return S_OK;
+            });
+
+    operation->put_Completed(cb.Get());
+    WaitForSingleObject(opCompleted.Get(), INFINITE);
+    hr = operation->GetResults(text.GetAddressOf());
+
+    if (hr != S_OK)
+    {
+        text.Release();
+        return NULL;
+    }
+
+    if (const WCHAR* wbuf_global = (const WCHAR*)text.GetRawBuffer(NULL))
+    {
+        int buf_len = ::WideCharToMultiByte(CP_UTF8, 0, wbuf_global, -1, NULL, 0, NULL, NULL);
+        g.ClipboardHandlerData.resize(buf_len);
+        ::WideCharToMultiByte(CP_UTF8, 0, wbuf_global, -1, g.ClipboardHandlerData.Data, buf_len, NULL, NULL);
+    }
+
+    text.Release();
+
+    return g.ClipboardHandlerData.Data;
+}
+
+static void ImGui_ImplUwp_SetClipboardTextFn(void*, const char* text)
+{
+    Microsoft::WRL::ComPtr<ABI::Windows::ApplicationModel::DataTransfer::IDataPackage> dataPkg;
+    Microsoft::WRL::ComPtr<ABI::Windows::ApplicationModel::DataTransfer::IClipboardStatics> clipboardStatics;
+    Windows::Foundation::ActivateInstance(Microsoft::WRL::Wrappers::HStringReference(RuntimeClass_Windows_ApplicationModel_DataTransfer_DataPackage).Get(), &dataPkg);
+    Windows::Foundation::GetActivationFactory(Microsoft::WRL::Wrappers::HStringReference(RuntimeClass_Windows_ApplicationModel_DataTransfer_Clipboard).Get(), &clipboardStatics);
+
+    HRESULT hr = dataPkg->put_RequestedOperation(ABI::Windows::ApplicationModel::DataTransfer::DataPackageOperation_Copy);
+    if (hr != S_OK)
+        return;
+
+    const int wbuf_length = ::MultiByteToWideChar(CP_UTF8, 0, text, -1, NULL, 0);
+    HGLOBAL wbuf_handle = ::GlobalAlloc(GMEM_MOVEABLE, (SIZE_T)wbuf_length * sizeof(WCHAR));
+    if (wbuf_handle == NULL)
+        return;
+
+    WCHAR* wbuf_global = (WCHAR*)::GlobalLock(wbuf_handle);
+    ::MultiByteToWideChar(CP_UTF8, 0, text, -1, wbuf_global, wbuf_length);
+    ::GlobalUnlock(wbuf_handle);
+
+    if (dataPkg->SetText(Microsoft::WRL::Wrappers::HStringReference(wbuf_global).Get()) != S_OK)
+    {
+        ::GlobalFree(wbuf_handle);
+        return;
+    }
+
+    clipboardStatics->SetContent(dataPkg.Get());
+    ::GlobalFree(wbuf_handle);
+}
+#endif
+
+//---------------------------------------------------------------------------------------------------------

--- a/third_party/imgui-uwp/backends/imgui_impl_uwp.h
+++ b/third_party/imgui-uwp/backends/imgui_impl_uwp.h
@@ -1,0 +1,27 @@
+// dear imgui: Platform Backend for Universal Windows Platform
+// This needs to be used along with a Renderer (e.g. DirectX11, DirectX12, SDL2..)
+
+// Implemented features:
+//  [X] Platform: Clipboard support (for Win32 & UWP this is actually part of core dear imgui)
+//  [X] Platform: Mouse support. Can discriminate Mouse/TouchScreen/Pen.
+//  [X] Platform: Keyboard support. Since 1.87 we are using the io.AddKeyEvent() function. Pass ImGuiKey values to all key functions e.g. ImGui::IsKeyPressed(ImGuiKey_Space).
+//  [X] Platform: Gamepad support. Enabled with 'io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad'.
+//  [X] Platform: Mouse cursor shape and visibility. Disable with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'.
+
+// Configs:
+//  #define IMGUI_DISABLE_UWP_DEFAULT_CLIPBOARD_FUNCTIONS     // Don't implement default WinRT clipboard handler.
+//  #define IMGUI_IMPL_UWP_DISABLE_GAMEPAD                    // Don't implement default XInput gamepad handler.
+
+// You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
+// Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
+// If you are new to Dear ImGui, read documentation from the docs/ folder + read the top of imgui.cpp.
+// Read online: https://github.com/ocornut/imgui/tree/master/docs
+
+#pragma once
+#include "imgui.h"      // IMGUI_IMPL_API
+
+IMGUI_IMPL_API bool     ImGui_ImplUwp_Init(void* core_window); // ABI::Windows::UI::Core::ICoreWindow*
+IMGUI_IMPL_API bool     ImGui_ImplUwp_InitForCurrentView();
+IMGUI_IMPL_API bool     ImGui_ImplUwp_InitForSwapChainPanel(void* swapchain_panel); // ABI::Windows::UI::Xaml::Controls::ISwapChainPanel*
+IMGUI_IMPL_API void     ImGui_ImplUwp_Shutdown();
+IMGUI_IMPL_API void     ImGui_ImplUwp_NewFrame();


### PR DESCRIPTION
I also changed the pending frames check in FFmpegDecoder.cpp from 1 to 2 with a check that it doesn't drop a frame if it's an IDR. This is just a temporary measure, but this value is pretty important and maybe we should consider making it configurable.

```
bool is_idr = (frame->pict_type == AV_PICTURE_TYPE_I) && (frame->flags & AV_FRAME_FLAG_KEY);
bool shouldDrop = LiGetPendingVideoFrames() > 2 && !is_idr;
ImGuiPlots::instance().observeFloat(PLOT_DROPPED_PACER, shouldDrop ? 1 : 0);
if (shouldDrop) {
	// Drop frame to reduce latency (unless it's an IDR frame)
	this->resources->GetStats()->SubmitDroppedFrame(1);
	return nullptr;
}
```

Another thing I haven't added is a way to enable or disable the graphs while still showing the stats. This will probably be a request but maybe someone else would like to tackle that one, it should be straightforward. There is also a cosmetic bug with the "Show Stats" / "Hide Stats" label state. 

Something to note about ImGui is that it draws everything every frame. It's very well optimized and I have tried to make the stat collection stuff very fast as well. But I just realized as I write this that I had an easy way to cap the graphs at 60fps on iOS, but I didn't do that here... so I probably need to fix that so they don't run at 120. I need to figure out how to use the profiler in Visual Studio, if you can even profile things running on Xbox.

To anyone testing this, be sure to try streaming at 1440p120 if 4k120 is giving you trouble. It makes a huge difference on my Series X. One of the best lightweight games to test 120fps is Hollow Knight. The native Xbox version has FPS Boost and runs like butter, and it's maybe 90% of the way there for me when streaming it.