### PR TITLE
ProcessInput: don't send input packets unless gamepad data has changed

### DIFF
--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -60,5 +60,6 @@ namespace moonlight_xbox_dx {
 		int activeGamepadMask = 0;
 		bool m_isHDR;
 		bool m_isRGBFull;
+		Windows::Gaming::Input::GamepadReading m_lastGamepadReading[16];
 	};
 }

--- a/Streaming/Pacer.cpp
+++ b/Streaming/Pacer.cpp
@@ -162,24 +162,6 @@ void Pacer::init(const std::shared_ptr<DX::DeviceResources> &res, int streamFps,
 
 // Vsync Emulator
 
-// Sleep until approximately targetQpc, then busy-wait to land precisely.
-// sleepSlackUs: how early (in microseconds) to stop sleeping and start spinning
-static inline void SleepUntilQpc(int64_t targetQpc, int64_t sleepSlackUs = 1000) {
-	const int64_t f = QpcFreq();
-	const int64_t slack = UsToQpc(sleepSlackUs);
-	for (;;) {
-		const int64_t now = QpcNow();
-		const int64_t remaining = targetQpc - now;
-		if (remaining <= 0) break;
-		if (remaining > slack) {
-			DWORD ms = (DWORD)(((remaining - slack) * 1000 + f / 2) / f);
-			if (ms > 0) Sleep(ms);
-			continue;
-		}
-		YieldProcessor();
-	}
-}
-
 void Pacer::vsyncEmulator() {
 	if (!SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_HIGHEST)) {
 		Utils::Logf("Failed to set vsyncEmulator priority: %d\n", GetLastError());


### PR DESCRIPTION
This seems to fix #217 and is much more efficient, but I'm not that familiar with the gamepad code so feel free to reject or modify, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced redundant gamepad events to lower input traffic and improve responsiveness.
  * Adjusted input polling to a steady 500 Hz interval for more consistent input delivery.
* **Stability**
  * Refined input/render timing and sleep behavior to reduce missed or duplicated input updates and improve loop stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->