### PR TITLE
Input: send empty packet after triggering menu to prevent host seeing a held button

### DIFF
--- a/Streaming/moonlight_xbox_dxMain.cpp
+++ b/Streaming/moonlight_xbox_dxMain.cpp
@@ -190,7 +190,6 @@ inline bool isPressed(Windows::Gaming::Input::GamepadButtons b, Windows::Gaming:
 // Process all input from the user before updating game state
 void moonlight_xbox_dxMain::ProcessInput()
 {
-
 	auto gamepads = Windows::Gaming::Input::Gamepad::Gamepads;
 	if (gamepads->Size == 0)return;
 	moonlightClient->SetGamepadCount(gamepads->Size);
@@ -216,12 +215,23 @@ void moonlight_xbox_dxMain::ProcessInput()
 			}
 		}
 		if (isCurrentlyPressed) {
-			m_streamPage->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, ref new Windows::UI::Core::DispatchedHandler([this]() {
+			DISPATCH_UI([this], {
 				Windows::UI::Xaml::Controls::Flyout::ShowAttachedFlyout(m_streamPage->m_flyoutButton);
-				}));
+			});
+
+			// send an empty controller packet, otherwise Sunshine may see View being kept held down,
+			// triggering the "Home/Guide Button Emulation Timeout" to send a Guide button press after a few seconds.
+			static Windows::Gaming::Input::GamepadReading emptyReading{};
+			ZeroMemory(&emptyReading, sizeof(GamepadReading));
+			moonlightClient->SendGamepadReading(i, emptyReading);
+
+			// disable all input until the flyout is closed
 			insideFlyout = true;
 		}
-		if (insideFlyout)return;
+		if (insideFlyout) {
+			return;
+		}
+
 		//If mouse mode is enabled the gamepad acts as a mouse, instead we pass the raw events to the host
 		if (keyboardMode) {
 			//B to close


### PR DESCRIPTION
Sunshine has a feature where if you hold the View (select) button for 2 seconds it will emulate a Guide button press. Bringing up the menu leaves either the View or Menu button (whichever was pressed first) in a held state from the host's point of view until the menu is closed. This patch sends a fully empty packet after the menu is triggered to cancel out any state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Fixed flyout invocation behavior when triggered by magic key combination to properly reset input state
- Prevents held input from being misinterpreted as continuous actions after triggering the flyout
- Improved input handling to block unintended operations while the flyout menu is active

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->