### PR TITLE
Fix use case of non-HDR console connecting to HDR host

### DIFF
--- a/State/MoonlightClient.h
+++ b/State/MoonlightClient.h
@@ -19,6 +19,7 @@ namespace moonlight_xbox_dx {
 	public:
 		MoonlightClient();
 		~MoonlightClient();
+		bool IsHDRSupported();
 		bool SetDisplayHDR(bool enabled, const SS_HDR_METADATA& sunshineHdrMetadata);
 		int StartStreaming(std::shared_ptr<DX::DeviceResources> res, StreamConfiguration ^config);
 		int Connect(const char* hostname);

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -283,7 +283,7 @@ static int load_serverinfo(PSERVER_DATA server, bool https) {
 
   if (httpsPortText != NULL)
     free(httpsPortText);
-  
+
   http_cleanup(curl);
 
   return ret;
@@ -712,13 +712,13 @@ int gs_applist(PSERVER_DATA server, PAPP_LIST *list) {
     ret = GS_ERROR;
   else if (xml_applist(data->memory, data->size, list) != GS_OK)
     ret = GS_INVALID;
-  
+
   http_cleanup(curl);
   http_free_data(data);
   return ret;
 }
 
-int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, bool sops, bool localaudio, int gamepad_mask) {
+int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, bool sops, bool localaudio, int gamepad_mask, bool isHDRSupported) {
   int ret = GS_OK;
   uuid_t uuid;
   char* result = NULL;
@@ -763,7 +763,7 @@ int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, b
   int fps = (server->isNvidiaSoftware && config->fps > 60) ? 0 : config->fps;
   snprintf(url, sizeof(url), "https://%s:%u/%s?uniqueid=%s&uuid=%s&appid=%d&mode=%dx%dx%d&additionalStates=1&sops=%d&rikey=%s&rikeyid=%d&localAudioPlayMode=%d&surroundAudioInfo=%d&remoteControllersBitmap=%d&gcmap=%d%s%s",
       server->serverInfo.address, server->httpsPort, server->currentGame ? "resume" : "launch", unique_id, uuid_str, appId, config->width, config->height, fps, sops, rikey_hex, rikeyid, localaudio, surround_info, gamepad_mask, gamepad_mask,
-      (config->supportedVideoFormats & VIDEO_FORMAT_MASK_10BIT) ? "&hdrMode=1&clientHdrCapVersion=0&clientHdrCapSupportedFlagsInUint32=0&clientHdrCapMetaDataId=NV_STATIC_METADATA_TYPE_1&clientHdrCapDisplayData=0x0x0x0x0x0x0x0x0x0x0" : "", LiGetLaunchUrlQueryParameters());
+      isHDRSupported ? "&hdrMode=1&clientHdrCapVersion=0&clientHdrCapSupportedFlagsInUint32=0&clientHdrCapMetaDataId=NV_STATIC_METADATA_TYPE_1&clientHdrCapDisplayData=0x0x0x0x0x0x0x0x0x0x0" : "", LiGetLaunchUrlQueryParameters());
   CURL* curl = get_curl_handle();
   if ((ret = http_request(curl, url, data)) == GS_OK)
     server->currentGame = appId;
@@ -792,7 +792,7 @@ int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, b
   cleanup:
   if (result != NULL)
     free(result);
-  
+
   http_cleanup(curl);
   http_free_data(data);
   return ret;
@@ -854,7 +854,7 @@ int gs_init(PSERVER_DATA server, char *address, unsigned short httpPort, const c
 
 int gs_appasset(PSERVER_DATA server, const char *keyDirectory, int appId) {
     int ret = GS_OK;
-    char url[4096];    
+    char url[4096];
     char* result = NULL;
 
     snprintf(url, sizeof(url), "https://%s:%u/appasset?appid=%d&AssetType=2&AssetIdx=0", server->serverInfo.address, server->httpsPort, appId);

--- a/libgamestream/client.h
+++ b/libgamestream/client.h
@@ -46,7 +46,7 @@ typedef struct _SERVER_DATA {
 } SERVER_DATA, *PSERVER_DATA;
 
 int gs_init(PSERVER_DATA server, char* address, unsigned short httpPort, const char *keyDirectory, int logLevel, bool unsupported);
-int gs_start_app(PSERVER_DATA server, PSTREAM_CONFIGURATION config, int appId, bool sops, bool localaudio, int gamepad_mask);
+int gs_start_app(PSERVER_DATA server, PSTREAM_CONFIGURATION config, int appId, bool sops, bool localaudio, int gamepad_mask, bool isHDRSupported);
 int gs_applist(PSERVER_DATA server, PAPP_LIST *app_list);
 int gs_unpair(PSERVER_DATA server);
 int gs_pair(PSERVER_DATA server, char* pin);


### PR DESCRIPTION
Xbox client was always reporting H265_MAIN10 as a supported codec, even if the console didn't support HDR due to running at a lower resolution or just not having an HDR TV. Sunshine doesn't support a way to request 10-bit SDR mode so this change has these SDR consoles fall back to only requesting 8-bit SDR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic HDR display capability detection to optimize video format selection during streaming.

* **Bug Fixes**
  * Fixed potential issue where 10-bit video encoding could be incorrectly requested on non-HDR capable displays, ensuring better compatibility and streaming reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->