### PR TITLE
[Feature] Prerelease signup

### DIFF
--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
 
   <Identity
     Name="50497EliaZammuto.MoonlightUWP"
-	Publisher="CN=mpotr"
+	Publisher="CN=CE07B73A-712E-4E05-932B-D08CE2C8A87C"
     Version="1.17.8.0" />
 
   <mp:PhoneIdentity PhoneProductId="05850585-e2ce-441e-beae-1c76b89fe7ed" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -9,7 +9,7 @@
 
   <Identity
     Name="50497EliaZammuto.MoonlightUWP"
-	Publisher="CN=CE07B73A-712E-4E05-932B-D08CE2C8A87C"
+	Publisher="CN=mpotr"
     Version="1.17.8.0" />
 
   <mp:PhoneIdentity PhoneProductId="05850585-e2ce-441e-beae-1c76b89fe7ed" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>

--- a/Pages/MoonlightSettings.xaml
+++ b/Pages/MoonlightSettings.xaml
@@ -42,6 +42,7 @@
                 <RowDefinition Height="auto"></RowDefinition>
                 <RowDefinition Height="auto"></RowDefinition>
                 <RowDefinition Height="auto"></RowDefinition>
+                <RowDefinition Height="auto"></RowDefinition>
             </Grid.RowDefinitions>
             <TextBlock Grid.Column="0" Grid.Row="0">Autostart Host:</TextBlock>
             <ComboBox Grid.Column="1" Grid.Row="0" x:Name="HostSelector" SelectionChanged="HostSelector_SelectionChanged"></ComboBox>
@@ -63,6 +64,7 @@
                 <CheckBox IsChecked="{x:Bind State.AlternateCombination,Mode=TwoWay}" XYFocusRight="{x:Bind KeyboardLayoutSelector}">Use LT+RT+LB+RB instead of Menu+View to show the menu</CheckBox>
             </StackPanel>
             <Button x:Name="WelcomeButton" Grid.Row="8" Grid.Column="1" Click="WelcomeButton_Click">Open Welcome Wizard</Button>
+            <Button x:Name="PreReleaseButton" Grid.Row="9" Grid.Column="1" Click="PreReleaseButton_Click">Prerelease Signup</Button>
         </Grid>
     </StackPanel>
 </Page>

--- a/Pages/MoonlightSettings.xaml.cpp
+++ b/Pages/MoonlightSettings.xaml.cpp
@@ -6,6 +6,7 @@
 #include "pch.h"
 #include "MoonlightSettings.xaml.h"
 #include "MoonlightWelcome.xaml.h"
+#include "PreReleaseSignupPage.xaml.h"
 #include "Utils.hpp"
 #include "Keyboard/KeyboardCommon.h"
 using namespace Windows::UI::Core;
@@ -91,6 +92,11 @@ void MoonlightSettings::OnBackRequested(Platform::Object^ e, Windows::UI::Core::
 void MoonlightSettings::WelcomeButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(MoonlightWelcome::typeid));
+}
+
+void MoonlightSettings::PreReleaseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	this->Frame->Navigate(Windows::UI::Xaml::Interop::TypeName(PreReleaseSignupPage::typeid));
 }
 
 void MoonlightSettings::LayoutSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e)

--- a/Pages/MoonlightSettings.xaml.h
+++ b/Pages/MoonlightSettings.xaml.h
@@ -31,6 +31,7 @@ namespace moonlight_xbox_dx
 		void backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void HostSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e);
 		void WelcomeButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void PreReleaseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void LayoutSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e);
 		void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/Pages/PreReleaseSignupPage.xaml
+++ b/Pages/PreReleaseSignupPage.xaml
@@ -1,0 +1,20 @@
+<Page
+    x:Class="moonlight_xbox_dx.PreReleaseSignupPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:moonlight_xbox_dx"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    <StackPanel Padding="32,64,32,32">
+        <Button Margin="0 0 0 16" Name="backButton" Click="backButton_Click">
+            <Button.Content>
+                <SymbolIcon Symbol="Back" />
+            </Button.Content>
+        </Button>
+        <TextBlock x:Name="StatusText" Text="Checking enrollment status..." Margin="0,8,0,8" />
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
+            <Button x:Name="OptInButton" Click="OptInButton_Click" Content="Sign up for Prerelease" IsEnabled="False" />
+            <Button x:Name="ManageButton" Click="ManageButton_Click" Content="Manage in Store" Margin="8,0,0,0" Visibility="Collapsed" />
+        </StackPanel>
+        <TextBlock x:Name="InfoText" Text="Join the prerelease to get early access to features." TextWrapping="Wrap" />
+    </StackPanel>
+</Page>

--- a/Pages/PreReleaseSignupPage.xaml
+++ b/Pages/PreReleaseSignupPage.xaml
@@ -13,7 +13,6 @@
         <TextBlock x:Name="StatusText" Text="Checking enrollment status..." Margin="0,8,0,8" />
         <StackPanel Orientation="Horizontal" Margin="0,8,0,8">
             <Button x:Name="OptInButton" Click="OptInButton_Click" Content="Sign up for Prerelease" IsEnabled="False" />
-            <Button x:Name="ManageButton" Click="ManageButton_Click" Content="Manage in Store" Margin="8,0,0,0" Visibility="Collapsed" />
         </StackPanel>
         <TextBlock x:Name="InfoText" Text="Join the prerelease to get early access to features." TextWrapping="Wrap" />
     </StackPanel>

--- a/Pages/PreReleaseSignupPage.xaml.cpp
+++ b/Pages/PreReleaseSignupPage.xaml.cpp
@@ -1,0 +1,54 @@
+#include "pch.h"
+#include "PreReleaseSignupPage.xaml.h"
+
+using namespace moonlight_xbox_dx;
+using namespace Platform;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Navigation;
+using namespace Windows::Services::Store;
+using namespace Windows::Foundation;
+
+PreReleaseSignupPage::PreReleaseSignupPage()
+{
+    InitializeComponent();
+    this->Loaded += ref new RoutedEventHandler(this, &PreReleaseSignupPage::OnLoaded);
+    this->Unloaded += ref new RoutedEventHandler(this, &PreReleaseSignupPage::OnUnloaded);
+}
+
+void PreReleaseSignupPage::OnLoaded(Platform::Object^ sender, RoutedEventArgs^ e)
+{
+    auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+    m_back_token = navigation->BackRequested += ref new EventHandler<Windows::UI::Core::BackRequestedEventArgs^>(this, &PreReleaseSignupPage::backButton_Click);
+
+    // StoreRequestHelper may not be available on all SDKs/configurations.
+    // For now, show a safe default state and avoid calling the Store API directly.
+    this->OptInButton->IsEnabled = false;
+    this->ManageButton->Visibility = Windows::UI::Xaml::Visibility::Collapsed;
+    this->StatusText->Text = "Prerelease signing not available on this platform.";
+}
+
+void PreReleaseSignupPage::OnUnloaded(Platform::Object^ sender, RoutedEventArgs^ e)
+{
+    auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
+    navigation->BackRequested -= m_back_token;
+}
+
+void PreReleaseSignupPage::backButton_Click(Platform::Object^ sender, Windows::UI::Core::BackRequestedEventArgs^ e)
+{
+    if (this->Frame->CanGoBack) this->Frame->GoBack();
+}
+
+void PreReleaseSignupPage::OptInButton_Click(Platform::Object^ sender, RoutedEventArgs^ e)
+{
+    // Store APIs may not be available in this build configuration; simulate success locally.
+    this->StatusText->Text = "Successfully signed up for prerelease.";
+    this->OptInButton->IsEnabled = false;
+    this->ManageButton->Visibility = Windows::UI::Xaml::Visibility::Visible;
+}
+
+void PreReleaseSignupPage::ManageButton_Click(Platform::Object^ sender, RoutedEventArgs^ e)
+{
+    // In this build we don't call the Store; show an informational message.
+    this->StatusText->Text = "Open the Store on your console to manage prerelease enrollment.";
+}

--- a/Pages/PreReleaseSignupPage.xaml.cpp
+++ b/Pages/PreReleaseSignupPage.xaml.cpp
@@ -1,13 +1,129 @@
 #include "pch.h"
 #include "PreReleaseSignupPage.xaml.h"
+#include <Utils.hpp>
+#include <functional>
 
 using namespace moonlight_xbox_dx;
 using namespace Platform;
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
-using namespace Windows::UI::Xaml::Navigation;
+using namespace Windows::UI::Core;
 using namespace Windows::Services::Store;
 using namespace Windows::Foundation;
+using namespace std;
+
+static const wchar_t* g_prerelease_flight_group_id = L"your-group-id-here";
+
+namespace {
+    bool IsStoreRequestHelperAvailable()
+    {
+        try {
+            return Windows::Foundation::Metadata::ApiInformation::IsTypePresent("Windows.Services.Store.StoreRequestHelper");
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+    bool TrySendStoreRequestAsync(Windows::Services::Store::StoreContext^ context, unsigned int requestKind, Platform::String^ paramsJson,
+        Windows::UI::Core::CoreDispatcher^ dispatcher, function<void(Platform::String^)> onSuccess,
+        function<void(Platform::Exception^)> onError)
+    {
+#if defined(USE_STORE_REQUEST_HELPER)
+        try {
+            auto op = Windows::Services::Store::StoreRequestHelper::SendRequestAsync(context, requestKind, paramsJson);
+            op->Completed = ref new Windows::Foundation::AsyncOperationCompletedHandler<Windows::Services::Store::StoreSendRequestResult^>(
+                [dispatcher, onSuccess, onError](Windows::Foundation::IAsyncOperation<Windows::Services::Store::StoreSendRequestResult^>^ asyncOp, Windows::Foundation::AsyncStatus status)
+            {
+                try
+                {
+                    if (status == Windows::Foundation::AsyncStatus::Completed)
+                    {
+                        auto result = asyncOp->GetResults();
+
+
+
+                        Platform::String^ response = nullptr;
+                        try {
+                            response = result->Response;
+                        }
+                        catch (...) {
+                            response = nullptr;
+                        }
+
+                        if (response == nullptr || response->Length() == 0)
+                        {
+                            moonlight_xbox_dx::Utils::Log(std::string("StoreRequestHelper response empty or missing\n"));
+                            if (onError)
+                            {
+                                dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, ref new Windows::UI::Core::DispatchedHandler([onError]() {
+                                    onError(ref new Platform::Exception(E_FAIL, ref new Platform::String(L"Store request returned no response")));
+                                }));
+                            }
+                        }
+                        else
+                        {
+                            moonlight_xbox_dx::Utils::Log(std::string("StoreRequestHelper response: ") + moonlight_xbox_dx::Utils::PlatformStringToStdString(response) + "\n");
+                            if (onSuccess)
+                            {
+                                dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, ref new Windows::UI::Core::DispatchedHandler([onSuccess, response]() {
+                                    onSuccess(response);
+                                }));
+                            }
+                        }
+                    }
+                }
+                catch (Platform::Exception^ ex)
+                {
+                    if (onError) onError(ex);
+                }
+            });
+            return true;
+        }
+        catch (Platform::Exception^ ex)
+        {
+            if (onError) onError(ex);
+            return false;
+        }
+#else
+        return false;
+#endif
+    }
+
+    void OpenStoreFallback(Platform::String^ statusMessage, Windows::UI::Xaml::Controls::TextBlock^ statusText)
+    {
+        try
+        {
+            auto uri = ref new Windows::Foundation::Uri(L"ms-windows-store://home");
+            auto _launchOp = Windows::System::Launcher::LaunchUriAsync(uri);
+            if (statusText)
+            {
+                statusText->Text = statusMessage;
+            }
+        }
+        catch (Platform::Exception^ ex)
+        {
+            auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
+            moonlight_xbox_dx::Utils::Log(std::string("OpenStoreFallback exception: ") + msg + "\n");
+            if (statusText)
+            {
+                statusText->Text = "Failed to open Store.";
+            }
+        }
+    }
+    static std::wstring EscapeForJsonString(const std::wstring& s)
+    {
+        std::wstring r;
+        r.reserve(s.size() * 2);
+        for (wchar_t c : s)
+        {
+            if (c == L'"') r += L"\\\"";
+            else if (c == L'\\') r += L"\\\\";
+            else r += c;
+        }
+        return r;
+    }
+}
 
 PreReleaseSignupPage::PreReleaseSignupPage()
 {
@@ -21,11 +137,92 @@ void PreReleaseSignupPage::OnLoaded(Platform::Object^ sender, RoutedEventArgs^ e
     auto navigation = Windows::UI::Core::SystemNavigationManager::GetForCurrentView();
     m_back_token = navigation->BackRequested += ref new EventHandler<Windows::UI::Core::BackRequestedEventArgs^>(this, &PreReleaseSignupPage::backButton_Click);
 
-    // StoreRequestHelper may not be available on all SDKs/configurations.
-    // For now, show a safe default state and avoid calling the Store API directly.
-    this->OptInButton->IsEnabled = false;
-    this->ManageButton->Visibility = Windows::UI::Xaml::Visibility::Collapsed;
-    this->StatusText->Text = "Prerelease signing not available on this platform.";
+    try
+    {
+        bool hasStoreHelper = IsStoreRequestHelperAvailable();
+        moonlight_xbox_dx::Utils::Log(std::string("PreRelease OnLoaded: ApiInformation::IsTypePresent(StoreRequestHelper) = ") + (hasStoreHelper ? "true\n" : "false\n"));
+#if defined(USE_STORE_REQUEST_HELPER)
+        moonlight_xbox_dx::Utils::Log("PreRelease compiled with USE_STORE_REQUEST_HELPER\n");
+#else
+        moonlight_xbox_dx::Utils::Log("PreRelease compiled WITHOUT USE_STORE_REQUEST_HELPER\n");
+#endif
+        if (hasStoreHelper)
+        {
+            this->StatusText->Text = "Checking prerelease enrollment status...";
+            try
+            {
+                auto context = Windows::Services::Store::StoreContext::GetDefault();
+                std::wstring inner = std::wstring(L"{ \"flightGroupId\": \"") + std::wstring(g_prerelease_flight_group_id) + std::wstring(L"\" }");
+                std::wstring esc = EscapeForJsonString(inner);
+                std::wstring full = std::wstring(L"{ \"type\": \"GetFlightMembershipStatus\", \"parameters\": \"") + esc + std::wstring(L"\" }");
+                auto paramsJson = ref new Platform::String(full.c_str());
+
+                bool started = TrySendStoreRequestAsync(context, 8u, paramsJson, this->Dispatcher,
+                    [this](Platform::String^ response) {
+                        std::string resp = moonlight_xbox_dx::Utils::PlatformStringToStdString(response);
+                        std::string lowered = resp;
+                        for (auto &c : lowered) c = (char)tolower(c);
+                        bool member = false;
+                        if (lowered.find("true") != std::string::npos) member = true;
+                        if (lowered.find("member") != std::string::npos) member = true;
+                        if (lowered.find("enroll") != std::string::npos) {
+                            if (lowered.find("not") != std::string::npos) member = false;
+                        }
+
+                        {
+                            this->m_isMember = member;
+                            if (member)
+                            {
+                                this->StatusText->Text = "You are enrolled in the prerelease.";
+                                this->OptInButton->Content = "Leave Prerelease";
+                            }
+                            else
+                            {
+                                this->StatusText->Text = "You are not enrolled. Click to join.";
+                                this->OptInButton->Content = "Join Prerelease";
+                            }
+                            this->OptInButton->IsEnabled = true;
+                        }
+                    },
+                    [this](Platform::Exception^ ex) {
+                        auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
+                        auto hr = ex->HResult;
+                        moonlight_xbox_dx::Utils::Log(std::string("StoreRequestHelper membership query error: HR=0x") + Utils::WideToNarrowString(std::to_wstring((long long)hr)) + " msg=" + msg + "\n");
+                        {
+                            std::string s = std::string("Error checking prerelease status: ") + msg;
+                            this->StatusText->Text = moonlight_xbox_dx::Utils::StringFromStdString(s);
+                        }
+                        this->OptInButton->IsEnabled = false;
+                    });
+
+                if (!started)
+                {
+                    this->StatusText->Text = "Unable to start Store membership query.";
+                    this->OptInButton->IsEnabled = false;
+                }
+            }
+            catch (Platform::Exception^ ex)
+            {
+                auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
+                moonlight_xbox_dx::Utils::Log(std::string("PreRelease membership check exception: ") + msg + "\n");
+                this->StatusText->Text = "Failed to verify prerelease status.";
+                this->OptInButton->IsEnabled = false;
+            }
+        }
+        else
+        {
+            this->OptInButton->IsEnabled = false;
+            this->StatusText->Text = "Prerelease signing not available on this platform.";
+        }
+    }
+    catch (Platform::Exception ^ex)
+    {
+        auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
+        auto hr = ex->HResult;
+        moonlight_xbox_dx::Utils::Log(std::string("PreRelease OnLoaded exception: HR=0x") + Utils::WideToNarrowString(std::to_wstring((long long)hr)) + " msg=" + msg + "\n");
+        this->OptInButton->IsEnabled = false;
+        this->StatusText->Text = "Error checking prerelease availability.";
+    }
 }
 
 void PreReleaseSignupPage::OnUnloaded(Platform::Object^ sender, RoutedEventArgs^ e)
@@ -41,14 +238,83 @@ void PreReleaseSignupPage::backButton_Click(Platform::Object^ sender, Windows::U
 
 void PreReleaseSignupPage::OptInButton_Click(Platform::Object^ sender, RoutedEventArgs^ e)
 {
-    // Store APIs may not be available in this build configuration; simulate success locally.
-    this->StatusText->Text = "Successfully signed up for prerelease.";
-    this->OptInButton->IsEnabled = false;
-    this->ManageButton->Visibility = Windows::UI::Xaml::Visibility::Visible;
-}
+    moonlight_xbox_dx::Utils::Log("PreRelease OptInButton_Click invoked\n");
+    try
+    {
+        bool hasStoreHelper = IsStoreRequestHelperAvailable();
+        moonlight_xbox_dx::Utils::Log(std::string("OptIn: ApiInformation reports StoreRequestHelper = ") + (hasStoreHelper ? "true\n" : "false\n"));
+        if (hasStoreHelper)
+        {
+            auto context = Windows::Services::Store::StoreContext::GetDefault();
+                std::wstring inner = std::wstring(L"{ \"flightGroupId\": \"") + std::wstring(g_prerelease_flight_group_id) + std::wstring(L"\" }");
+                std::wstring esc = EscapeForJsonString(inner);
+                std::wstring full = std::wstring(L"{ \"type\": \"AddToFlightGroup\", \"parameters\": \"") + esc + std::wstring(L"\" }");
+            auto paramsJson = ref new Platform::String(full.c_str());
 
-void PreReleaseSignupPage::ManageButton_Click(Platform::Object^ sender, RoutedEventArgs^ e)
-{
-    // In this build we don't call the Store; show an informational message.
-    this->StatusText->Text = "Open the Store on your console to manage prerelease enrollment.";
+            if (this->m_isMember)
+            {
+                std::wstring inner = std::wstring(L"{ \"flightGroupId\": \"") + std::wstring(g_prerelease_flight_group_id) + std::wstring(L"\" }");
+                std::wstring esc = EscapeForJsonString(inner);
+                std::wstring full = std::wstring(L"{ \"type\": \"RemoveFromFlightGroup\", \"parameters\": \"") + esc + std::wstring(L"\" }");
+                auto paramsJson = ref new Platform::String(full.c_str());
+                bool started = TrySendStoreRequestAsync(context, 8u, paramsJson, this->Dispatcher,
+                    [this](Platform::String^ response) {
+                        this->StatusText->Text = response;
+                        this->m_isMember = false;
+                        this->OptInButton->Content = "Join Prerelease";
+                    },
+                    [this](Platform::Exception^ ex) {
+                        auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
+                        auto hr = ex->HResult;
+                        moonlight_xbox_dx::Utils::Log(std::string("StoreRequestHelper leave callback error: HR=0x") + Utils::WideToNarrowString((std::wstring)L"" + std::to_wstring(hr)) + " msg=" + msg + "\n");
+                        {
+                            std::string s = std::string("Failed to leave prerelease: ") + msg;
+                            this->StatusText->Text = moonlight_xbox_dx::Utils::StringFromStdString(s);
+                        }
+                    });
+                if (!started)
+                {
+                    this->StatusText->Text = "Failed to start leave request.";
+                }
+            }
+            else
+            {
+                std::wstring inner = std::wstring(L"{ \"flightGroupId\": \"") + std::wstring(g_prerelease_flight_group_id) + std::wstring(L"\" }");
+                std::wstring esc = EscapeForJsonString(inner);
+                std::wstring full = std::wstring(L"{ \"type\": \"AddToFlightGroup\", \"parameters\": \"") + esc + std::wstring(L"\" }");
+                auto paramsJson = ref new Platform::String(full.c_str());
+                bool started = TrySendStoreRequestAsync(context, 8u, paramsJson, this->Dispatcher,
+                    [this](Platform::String^ response) {
+                        this->StatusText->Text = response;
+                        this->m_isMember = true;
+                        this->OptInButton->Content = "Leave Prerelease";
+                    },
+                    [this](Platform::Exception^ ex) {
+                        auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
+                        auto hr = ex->HResult;
+                        moonlight_xbox_dx::Utils::Log(std::string("StoreRequestHelper join callback error: HR=0x") + Utils::WideToNarrowString((std::wstring)L"" + std::to_wstring(hr)) + " msg=" + msg + "\n");
+                        {
+                            std::string s = std::string("Failed to join prerelease: ") + msg;
+                            this->StatusText->Text = moonlight_xbox_dx::Utils::StringFromStdString(s);
+                        }
+                    });
+                if (!started)
+                {
+                    this->StatusText->Text = "Failed to start join request.";
+                }
+            }
+        }
+        else
+        {
+            this->StatusText->Text = "Prerelease signing not available on this platform.";
+            this->OptInButton->IsEnabled = false;
+        }
+    }
+    catch (Platform::Exception ^ex)
+    {
+        auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
+        auto hr = ex->HResult;
+        moonlight_xbox_dx::Utils::Log(std::string("OptIn exception: HR=0x") + Utils::WideToNarrowString(std::to_wstring((long long)hr)) + " msg=" + msg + "\n");
+        this->StatusText->Text = "Failed to start prerelease signup.";
+    }
 }

--- a/Pages/PreReleaseSignupPage.xaml.cpp
+++ b/Pages/PreReleaseSignupPage.xaml.cpp
@@ -41,8 +41,6 @@ namespace {
                     {
                         auto result = asyncOp->GetResults();
 
-
-
                         Platform::String^ response = nullptr;
                         try {
                             response = result->Response;
@@ -89,28 +87,7 @@ namespace {
         return false;
 #endif
     }
-
-    void OpenStoreFallback(Platform::String^ statusMessage, Windows::UI::Xaml::Controls::TextBlock^ statusText)
-    {
-        try
-        {
-            auto uri = ref new Windows::Foundation::Uri(L"ms-windows-store://home");
-            auto _launchOp = Windows::System::Launcher::LaunchUriAsync(uri);
-            if (statusText)
-            {
-                statusText->Text = statusMessage;
-            }
-        }
-        catch (Platform::Exception^ ex)
-        {
-            auto msg = moonlight_xbox_dx::Utils::PlatformStringToStdString(ex->Message);
-            moonlight_xbox_dx::Utils::Log(std::string("OpenStoreFallback exception: ") + msg + "\n");
-            if (statusText)
-            {
-                statusText->Text = "Failed to open Store.";
-            }
-        }
-    }
+    
     static std::wstring EscapeForJsonString(const std::wstring& s)
     {
         std::wstring r;

--- a/Pages/PreReleaseSignupPage.xaml.h
+++ b/Pages/PreReleaseSignupPage.xaml.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Pages\PreReleaseSignupPage.g.h"
+
+namespace moonlight_xbox_dx
+{
+    public ref class PreReleaseSignupPage sealed
+    {
+    public:
+        PreReleaseSignupPage();
+    private:
+        void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void backButton_Click(Platform::Object^ sender, Windows::UI::Core::BackRequestedEventArgs^ e);
+        void OptInButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void ManageButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+
+        Windows::Foundation::EventRegistrationToken m_back_token;
+    };
+}

--- a/Pages/PreReleaseSignupPage.xaml.h
+++ b/Pages/PreReleaseSignupPage.xaml.h
@@ -12,8 +12,7 @@ namespace moonlight_xbox_dx
         void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void backButton_Click(Platform::Object^ sender, Windows::UI::Core::BackRequestedEventArgs^ e);
         void OptInButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-        void ManageButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-
         Windows::Foundation::EventRegistrationToken m_back_token;
+        bool m_isMember;
     };
 }

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -149,7 +149,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)\third_party\DirectXTK\inc;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;USE_STORE_REQUEST_HELPER;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
@@ -245,7 +245,7 @@
       <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)\third_party\DirectXTK\inc;$(ProjectDir)vcpkg_installed\x64-uwp\include;$(IntermediateOutputPath);third_party\moonlight-common-c\src;third_party\imgui;third_party\imgui\backends;third_party\imgui-uwp\backends;third_party\implot;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
-      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_DEBUG;USE_STORE_REQUEST_HELPER;%(PreprocessorDefinitions);_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -136,7 +136,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageDir>C:\Progetti\moonlight-xbox-dx\AppPackages\moonlight-xbox-dx\</AppxPackageDir>
-    <PackageCertificateThumbprint>12EF20E0A548743F0540AA6555D4E4D12DD7E9B3</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>3B1A568311E29FB84FB743091B0D1031F488423C</PackageCertificateThumbprint>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -136,7 +136,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageDir>C:\Progetti\moonlight-xbox-dx\AppPackages\moonlight-xbox-dx\</AppxPackageDir>
-    <PackageCertificateThumbprint>12EF20E0A548743F0540AA6555D4E4D12DD7E9B3</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>3B1A568311E29FB84FB743091B0D1031F488423C</PackageCertificateThumbprint>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>
@@ -358,6 +358,9 @@
     <ClInclude Include="Pages\MoonlightSettings.xaml.h">
       <DependentUpon>Pages\MoonlightSettings.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Pages\PreReleaseSignupPage.xaml.h">
+      <DependentUpon>Pages\PreReleaseSignupPage.xaml</DependentUpon>
+    </ClInclude>
     <ClInclude Include="State\ScreenResolution.h" />
     <ClInclude Include="State\MoonlightApp.h" />
     <ClInclude Include="Pages\AppPage.xaml.h">
@@ -383,6 +386,10 @@
     <ClCompile Include="App.xaml.cpp">
       <DependentUpon>App.xaml</DependentUpon>
     </ClCompile>
+    <Page Include="Pages\PreReleaseSignupPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <ClCompile Include="Common\TextConsole.cpp" />
     <ClCompile Include="Keyboard\kbda1.cpp" />
     <ClCompile Include="Keyboard\kbda2.cpp" />
@@ -490,6 +497,9 @@
     </ClCompile>
     <ClCompile Include="Pages\MoonlightSettings.xaml.cpp">
       <DependentUpon>Pages\MoonlightSettings.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="Pages\PreReleaseSignupPage.xaml.cpp">
+      <DependentUpon>Pages\PreReleaseSignupPage.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="State\ScreenResolution.cpp" />
     <ClCompile Include="State\MoonlightApp.cpp" />

--- a/moonlight-xbox-dx.vcxproj
+++ b/moonlight-xbox-dx.vcxproj
@@ -136,7 +136,7 @@
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <AppxPackageDir>C:\Progetti\moonlight-xbox-dx\AppPackages\moonlight-xbox-dx\</AppxPackageDir>
-    <PackageCertificateThumbprint>3B1A568311E29FB84FB743091B0D1031F488423C</PackageCertificateThumbprint>
+    <PackageCertificateThumbprint>12EF20E0A548743F0540AA6555D4E4D12DD7E9B3</PackageCertificateThumbprint>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Link>


### PR DESCRIPTION
Creates a button in MoonlightSettings that brings you to the prerelease sign-up.

The prerelease sign-up page will check your status on entry and let you opt-in or opt-out, based on your status.

This is just a PoC and needs to have the flight group id entered yet.