### PR TITLE
Fix hdrMode=1 query string to use Enable HDR checkbox

### DIFF
--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -264,7 +264,9 @@ int MoonlightClient::StartStreaming(std::shared_ptr<DX::DeviceResources> res, St
 	config.supportedVideoFormats = VIDEO_FORMAT_H264;
 	if (!IsXboxOneVCR()) {
 		config.supportedVideoFormats |= VIDEO_FORMAT_H265;
-		config.supportedVideoFormats |= VIDEO_FORMAT_H265_MAIN10;
+		if (sConfig->enableHDR) {
+			config.supportedVideoFormats |= VIDEO_FORMAT_H265_MAIN10;
+		}
 	}
 
 	config.audioConfiguration = AUDIO_CONFIGURATION_STEREO;


### PR DESCRIPTION
This fixes a bug where the weird hdrMode=1 query string, and other junk was always being sent. This broke Sunshine's "auto-switch-to-HDR" feature. Now the MAIN10 variant of H265 is only reported when the HDR checkbox is enabled.

Fixes #238 

```
(config->supportedVideoFormats & VIDEO_FORMAT_MASK_10BIT) ? "&hdrMode=1&clientHdrCapVersion=0&clientHdrCapSupportedFlagsInUint32=0&clientHdrCapMetaDataId=NV_STATIC_METADATA_TYPE_1&clientHdrCapDisplayData=0x0x0x0x0x0x0x0x0x0x0" : ""
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * H.265 Main 10 video format availability is now contingent on HDR being enabled. The format will only be offered to users when HDR support is explicitly turned on.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->