### PR TITLE
Fix stream load display

### DIFF
--- a/Common/DeviceResources.cpp
+++ b/Common/DeviceResources.cpp
@@ -254,7 +254,7 @@ void DX::DeviceResources::CreateWindowSizeDependentResources()
 		swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 		swapChainDesc.Flags = 0;
 		swapChainDesc.Scaling = DXGI_SCALING_STRETCH;
-		swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_PREMULTIPLIED;
+		swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 
 		// This sequence obtains the DXGI factory that was used to create the Direct3D device above.
 		ComPtr<IDXGIDevice3> dxgiDevice;
@@ -341,14 +341,6 @@ void DX::DeviceResources::CreateWindowSizeDependentResources()
 		);
 
 	m_d3dContext->RSSetViewports(1, &m_screenViewport);
-
-	// One-time clear to transparent so XAML children (ProgressView) will composite on top.
-	if (m_d3dRenderTargetView)
-	{
-		const FLOAT clearColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f }; // transparent
-		m_d3dContext->ClearRenderTargetView(m_d3dRenderTargetView.Get(), clearColor);
-		Present();
-	}
 }
 
 // Determine the dimensions of the render target and whether it will be scaled down.

--- a/Pages/StreamPage.xaml
+++ b/Pages/StreamPage.xaml
@@ -11,67 +11,71 @@
     Loaded="Page_Loaded"
     Unloaded="Page_Unloaded">
 
-    <SwapChainPanel x:Name="swapChainPanel" Margin="{x:Bind State.ScreenMargin}">
-        <StackPanel x:Name="ProgressView" HorizontalAlignment="Center" VerticalAlignment="Center"  Orientation="Vertical">
-            <muxc:ProgressRing Width="64" Height="64" IsActive="True" Margin="0,0,0,16" ></muxc:ProgressRing>
-            <TextBlock x:Name="StatusText">Initializing Moonlight...</TextBlock>
-        </StackPanel>
-        <StackPanel HorizontalAlignment="Stretch" x:Name="KeyboardView" Visibility="Collapsed" VerticalAlignment="Bottom" Margin="64,0,64,16" Padding="8,8,8,8">
-            <StackPanel.Background>
-                <SolidColorBrush Color="{ThemeResource SystemColorBackgroundColor}" Opacity="0.75" />
-            </StackPanel.Background>
-            <local:KeyboardControl OnKeyDown="Keyboard_OnKeyDown" OnKeyUp="Keyboard_OnKeyUp" x:Name="Keyboard"/>
-        </StackPanel>
-        <Button Click="flyoutButton_Click" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,20,20" x:Name="flyoutButton" AllowFocusOnInteraction="false" Grid.Column="1" Opacity="0">
-            <FlyoutBase.AttachedFlyout>
-                <MenuFlyout x:Name="ActionsFlyout" Closed="ActionsFlyout_Closed" AllowFocusOnInteraction="false" Placement="TopEdgeAlignedRight">
-                    <MenuFlyoutItem x:Name="toggleMouseButton" Text="Enable Mouse Mode" Click="toggleMouseButton_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xE962;" />
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutSubItem Text="Other Actions">
-                        <MenuFlyoutItem x:Name="guideButtonShort" Text="Guide Button (short)" Click="guideButtonShort_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+    <Grid>
+        <SwapChainPanel x:Name="swapChainPanel" Margin="{x:Bind State.ScreenMargin}">
+            <StackPanel HorizontalAlignment="Stretch" x:Name="KeyboardView" Visibility="Collapsed" VerticalAlignment="Bottom" Margin="64,0,64,16" Padding="8,8,8,8">
+                <StackPanel.Background>
+                    <SolidColorBrush Color="{ThemeResource SystemColorBackgroundColor}" Opacity="0.75" />
+                </StackPanel.Background>
+                <local:KeyboardControl OnKeyDown="Keyboard_OnKeyDown" OnKeyUp="Keyboard_OnKeyUp" x:Name="Keyboard"/>
+            </StackPanel>
+            <Button Click="flyoutButton_Click" IsTabStop="False" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,20,20" x:Name="flyoutButton" AllowFocusOnInteraction="false" Grid.Column="1" Opacity="0">
+                <FlyoutBase.AttachedFlyout>
+                    <MenuFlyout x:Name="ActionsFlyout" Closed="ActionsFlyout_Closed" AllowFocusOnInteraction="false" Placement="TopEdgeAlignedRight">
+                        <MenuFlyoutItem x:Name="toggleMouseButton" Text="Enable Mouse Mode" Click="toggleMouseButton_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
                             <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xe80f;" />
+                                <FontIcon Glyph="&#xE962;" />
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
-                        <MenuFlyoutItem x:Name="guideButtonLong" Text="Guide Button (long)" Click="guideButtonLong_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                        <MenuFlyoutSubItem Text="Other Actions">
+                            <MenuFlyoutItem x:Name="guideButtonShort" Text="Guide Button (short)" Click="guideButtonShort_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xe80f;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem x:Name="guideButtonLong" Text="Guide Button (long)" Click="guideButtonLong_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xe80f;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem x:Name="toggleHDR_WinAltB" Text="Toggle HDR (Win-Alt-B)" Click="toggleHDR_WinAltB_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xe706;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                        </MenuFlyoutSubItem>
+                        <MenuFlyoutSeparator></MenuFlyoutSeparator>
+                        <MenuFlyoutItem x:Name="toggleStatsButton" Text="Show Stats" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" Click="toggleStatsButton_Click">
                             <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xe80f;" />
+                                <FontIcon Glyph="&#xEC48;" />
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
-                        <MenuFlyoutItem x:Name="toggleHDR_WinAltB" Text="Toggle HDR (Win-Alt-B)" Click="toggleHDR_WinAltB_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                        <MenuFlyoutItem x:Name="toggleLogsButton" Text="Show Logs" AllowFocusOnInteraction="false" Click="toggleLogsButton_Click"  FocusVisualSecondaryThickness="0.5" >
                             <MenuFlyoutItem.Icon>
-                                <FontIcon Glyph="&#xe706;" />
+                                <FontIcon Glyph="&#xF0B5;" />
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
-                    </MenuFlyoutSubItem>
-                    <MenuFlyoutSeparator></MenuFlyoutSeparator>
-                    <MenuFlyoutItem x:Name="toggleStatsButton" Text="Show Stats" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" Click="toggleStatsButton_Click">
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xEC48;" />
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutItem x:Name="toggleLogsButton" Text="Show Logs" AllowFocusOnInteraction="false" Click="toggleLogsButton_Click"  FocusVisualSecondaryThickness="0.5" >
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xF0B5;" />
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutSeparator></MenuFlyoutSeparator>
-                    <MenuFlyoutItem x:Name="disonnectButton" Text="Disconnect" Click="disonnectButton_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xE72D;" />
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                    <MenuFlyoutItem x:Name="disconnectAndCloseButton" Text="Disconnect and Close" Click="disconnectAndCloseButton_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
-                        <MenuFlyoutItem.Icon>
-                            <FontIcon Glyph="&#xE71A;" />
-                        </MenuFlyoutItem.Icon>
-                    </MenuFlyoutItem>
-                </MenuFlyout>
-            </FlyoutBase.AttachedFlyout>
-        </Button>
-    </SwapChainPanel>
+                        <MenuFlyoutSeparator></MenuFlyoutSeparator>
+                        <MenuFlyoutItem x:Name="disonnectButton" Text="Disconnect" Click="disonnectButton_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE72D;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                        <MenuFlyoutItem x:Name="disconnectAndCloseButton" Text="Disconnect and Close" Click="disconnectAndCloseButton_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                            <MenuFlyoutItem.Icon>
+                                <FontIcon Glyph="&#xE71A;" />
+                            </MenuFlyoutItem.Icon>
+                        </MenuFlyoutItem>
+                    </MenuFlyout>
+                </FlyoutBase.AttachedFlyout>
+            </Button>
+        </SwapChainPanel>
+        <Grid x:Name="ProgressView" Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+            <StackPanel x:Name="ProgressStack" HorizontalAlignment="Center" VerticalAlignment="Center"  Orientation="Vertical">
+                <muxc:ProgressRing x:Name="MainProgressRing" Width="64" Height="64" IsActive="True" Margin="0,0,0,16" />
+                <TextBlock x:Name="StatusText" Text="Initializing Moonlight..."/>
+            </StackPanel>
+        </Grid>
+    </Grid>
 
 </Page>

--- a/Pages/StreamPage.xaml.h
+++ b/Pages/StreamPage.xaml.h
@@ -43,9 +43,15 @@ namespace moonlight_xbox_dx
 			}
 		}
 
-		property StackPanel^ m_progressView {
-			StackPanel^ get() {
+		property Grid^ m_progressView {
+			Grid^ get() {
 				return this->ProgressView;
+			}
+		}
+
+		property Microsoft::UI::Xaml::Controls::ProgressRing^ m_progressRing {
+		    Microsoft::UI::Xaml::Controls::ProgressRing ^ get() {
+				return this->MainProgressRing;
 			}
 		}
 

--- a/Streaming/moonlight_xbox_dxMain.cpp
+++ b/Streaming/moonlight_xbox_dxMain.cpp
@@ -22,9 +22,7 @@ extern "C" {
 // Loads and initializes application assets when the application is loaded.
 moonlight_xbox_dxMain::moonlight_xbox_dxMain(const std::shared_ptr<DX::DeviceResources>& deviceResources, StreamPage^ streamPage, MoonlightClient* client, StreamConfiguration^ configuration) :
 
-	m_deviceResources(deviceResources), m_pointerLocationX(0.0f), m_streamPage(streamPage), moonlightClient(client)
-{
-	streamPage->m_progressView->Visibility = Windows::UI::Xaml::Visibility::Visible;
+	m_deviceResources(deviceResources), m_pointerLocationX(0.0f), m_streamPage(streamPage), moonlightClient(client) {
 	
 	// Register to be notified if the Device is lost or recreated
 	m_deviceResources->RegisterDeviceNotify(this);
@@ -55,12 +53,15 @@ moonlight_xbox_dxMain::moonlight_xbox_dxMain(const std::shared_ptr<DX::DeviceRes
 		});
 
 	client->OnCompleted = ([streamPage]() {
+		// Give stream a moment to stabilize before hiding progress view
+		Sleep(500);
+		streamPage->m_progressRing->IsActive = false;
 		streamPage->m_progressView->Visibility = Windows::UI::Xaml::Visibility::Collapsed;
-		});
+	});
 
 	client->OnFailed = ([streamPage](int status, int error, char* message) {
 		streamPage->m_statusText->Text = Utils::StringFromStdString(std::string(message));
-		});
+	});
 
 	client->SetHDR = ([this](bool v) {
 		this->m_sceneRenderer->SetHDR(v);
@@ -272,8 +273,8 @@ void moonlight_xbox_dxMain::ProcessInput()
 		}
 		for (auto k : magicKey) {
 			if ((reading.Buttons & k) != k) {
-				isCurrentlyPressed = false;
-				break;
+			 isCurrentlyPressed = false;
+			 break;
 			}
 		}
 		if (isCurrentlyPressed) {
@@ -415,7 +416,7 @@ void moonlight_xbox_dxMain::ProcessInput()
 				if (GetApplicationState()->EnableKeyboard) {
 					m_streamPage->Dispatcher->RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, ref new Windows::UI::Core::DispatchedHandler([this]() {
 						m_streamPage->m_keyboardView->Visibility = Windows::UI::Xaml::Visibility::Visible;
-						}));
+					}));
 					keyboardMode = true;
 				}
 				else {


### PR DESCRIPTION
Our current "master" has no loading screen going into a stream. In previous releases, concurrent streams have had unreliable loading screens.

This fixes it reliably for every stream.

Most of it just ended up being UI timing and thread-blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Other Actions" menu with guide and HDR toggle options.

* **Bug Fixes**
  * Added 500ms delay before hiding progress indicators for better user feedback.

* **Refactor**
  * Reorganized stream page UI layout with improved container structure.
  * Implemented deferred initialization for better startup performance.
  * Enhanced page lifecycle management with proper cleanup on unload.
  * Consolidated menu items and updated icon glyphs for visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->