### PR TITLE
Add back init_mdns

### DIFF
--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -267,6 +267,7 @@ void HostSelectorPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEv
 	Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->SetDesiredBoundsMode(Windows::UI::ViewManagement::ApplicationViewBoundsMode::UseVisible);
 	continueFetch.store(true);
 	Concurrency::create_task([this] {
+		init_mdns();
 		while (continueFetch.load()) {
 			query_mdns();
 			for (auto a : GetApplicationState()->SavedHosts) {


### PR DESCRIPTION
My changes accidentally took this out. Sorry!

This fix is also in the mdns handler refactor. I just wanted to keep it separate incase you do not want to merge that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MDNS initialization sequence in host selection to ensure proper setup before device discovery attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->