### PR TITLE
Support for changing the frame pacing mode via quick menu

### DIFF
--- a/Pages/StreamPage.xaml
+++ b/Pages/StreamPage.xaml
@@ -47,6 +47,11 @@
                                     <FontIcon Glyph="&#xe706;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
+                            <MenuFlyoutItem x:Name="toggleFramePacing" Text="Switch frame pacing mode" Click="toggleFramePacing_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE8B9;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                         </MenuFlyoutSubItem>
                         <MenuFlyoutSeparator></MenuFlyoutSeparator>
                         <MenuFlyoutItem x:Name="toggleStatsButton" Text="{x:Bind ShowStats, Mode=OneWay, Converter={StaticResource BoolToTextConverter}, ConverterParameter='Hide Stats|Show Stats'}" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" Click="toggleStatsButton_Click">

--- a/Pages/StreamPage.xaml.cpp
+++ b/Pages/StreamPage.xaml.cpp
@@ -64,7 +64,7 @@ void StreamPage::Page_Loaded(Platform::Object ^ sender, Windows::UI::Xaml::Route
 
 	keyDownHandler = (Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow ^, Windows::UI::Core::KeyEventArgs ^>(this, &StreamPage::OnKeyDown));
 	keyUpHandler = (Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyUp += ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow ^, Windows::UI::Core::KeyEventArgs ^>(this, &StreamPage::OnKeyUp));
-	
+
 	try {
 		m_deviceResources->SetSwapChainPanel(swapChainPanel);
 	} catch (...) {
@@ -79,7 +79,7 @@ void StreamPage::Page_Loaded(Platform::Object ^ sender, Windows::UI::Xaml::Route
 		if (that == nullptr) return;
 		try {
 			that->m_main = std::unique_ptr<moonlight_xbox_dxMain>(new moonlight_xbox_dxMain(that->m_deviceResources, that, new MoonlightClient(), that->configuration));
-			
+
 			DISPATCH_UI([that], {
 				try {
 					that->m_main->CreateDeviceDependentResources();
@@ -308,6 +308,13 @@ void StreamPage::guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xa
 void StreamPage::toggleHDR_WinAltB_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->m_main->SendWinAltB();
+}
+
+void StreamPage::toggleFramePacing_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	// thread safe atomic bool
+	bool isImmediate = Pacer::instance().getPacingImmediate();
+	Pacer::instance().setPacingImmediate(isImmediate ? false : true);
 }
 
 void StreamPage::OnPropertyChanged(Platform::String^ propertyName)

--- a/Pages/StreamPage.xaml.h
+++ b/Pages/StreamPage.xaml.h
@@ -146,10 +146,11 @@ namespace moonlight_xbox_dx
 		void guideButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void toggleHDR_WinAltB_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void toggleFramePacing_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 
-        bool m_mouseMode = false;
-	    bool m_showLogs = false;
-	    bool m_showStats = false;
+		bool m_mouseMode = false;
+		bool m_showLogs = false;
+		bool m_showStats = false;
 	};
 }
 

--- a/State/Stats.h
+++ b/State/Stats.h
@@ -63,7 +63,7 @@ namespace moonlight_xbox_dx
 		void SubmitAvgQueueSize(float avgQueueSize);
 		void SubmitPacerTime(int64_t pacerTimeQpc);
 		void SubmitPresentPacing(double presentDisplayMs);
-		void SubmitRenderStats(int64_t preWaitTimeUs, int64_t renderTimeUs, int64_t presentTimeUs, bool hitDeadline);
+		void SubmitRenderStats(double preWaitTimeMs, double renderTimeMs, double presentTimeMs, bool hitDeadline);
 
 	private:
 		void addVideoStats(DX::StepTimer const& timer, VIDEO_STATS& src, VIDEO_STATS& dst);

--- a/Streaming/Pacer.h
+++ b/Streaming/Pacer.h
@@ -20,6 +20,8 @@ class Pacer {
 
 	void deinit();
 	void init(const std::shared_ptr<DX::DeviceResources> &res, int maxVideoFps, double refreshRate, bool framePacingImmediate);
+	bool getPacingImmediate();
+	void setPacingImmediate(bool framePacingImmediate);
 	void waitForFrame(double timeoutMs);
 	bool renderOnMainThread(std::shared_ptr<moonlight_xbox_dx::VideoRenderer> &sceneRenderer);
 	bool waitBeforePresent(int64_t deadline);
@@ -51,7 +53,7 @@ class Pacer {
 	std::atomic<bool> m_Stopping{false};
 	int m_StreamFps;
 	double m_RefreshRate;
-	bool m_FramePacingImmediate;
+	std::atomic<bool> m_FramePacingImmediate;
 
 	FrameCadence m_FrameCadence;
 	AVFrame* m_CurrentFrame = nullptr;


### PR DESCRIPTION
The pacer supports changing the mode on-the-fly, so it makes sense to add it to the quick menu. This PR also includes a bit of an improvement to `waitForFrame()` to try and more accurately hit the timeout. This is the main cause of missed presents, so it now waits in smaller chunks. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New menu option under "Other Actions" to switch frame pacing mode.
  * Pacing mode now displayed in performance statistics.

* **Bug Fixes**
  * Improved frame timing, deadline handling, and render-loop responsiveness to reduce missed frames.

* **Refactor**
  * Concurrency and timing internals reworked for more reliable pacing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->