### PR TITLE
Encrypt audio stream (fixes #230)

### DIFF
--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -259,7 +259,7 @@ int MoonlightClient::StartStreaming(std::shared_ptr<DX::DeviceResources> res, St
 	}
 	config.colorRange = this->IsRGBFull() ? COLOR_RANGE_FULL : COLOR_RANGE_LIMITED;
 	config.colorSpace = COLORSPACE_REC_601;
-	config.encryptionFlags = 0;
+	config.encryptionFlags = ENCFLG_AUDIO;
 	config.packetSize = 1024;
 	config.supportedVideoFormats = VIDEO_FORMAT_H264;
 	if (!IsXboxOneVCR()) {

--- a/moonlight-xbox-dx.sln
+++ b/moonlight-xbox-dx.sln
@@ -4,6 +4,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "moonlight-xbox-dx", "moonlight-xbox-dx.vcxproj", "{0D5DFFAA-E5DD-4A61-B3EC-0A73EF86C9B1}"
+	ProjectSection(ProjectDependencies) = postProject
+		{842AAF8B-4505-3D3B-AAE5-CFF297F90298} = {842AAF8B-4505-3D3B-AAE5-CFF297F90298}
+		{873D03B2-B99F-3917-AFDC-9FB954F9962E} = {873D03B2-B99F-3917-AFDC-9FB954F9962E}
+		{E025A414-0DA7-3C61-A890-9487ED6E1D91} = {E025A414-0DA7-3C61-A890-9487ED6E1D91}
+		{F4776924-619C-42C7-88B2-82C947CCC9E7} = {F4776924-619C-42C7-88B2-82C947CCC9E7}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "moonlight-common-c", "third_party\moonlight-common-c\build\moonlight-common-c.vcxproj", "{E025A414-0DA7-3C61-A890-9487ED6E1D91}"
 EndProject


### PR DESCRIPTION
Wolf currently has a bug where it doesn't support sending unencrypted audio streams, but really, it should be cheap enough to encrypt audio that we should just always do it.

This PR also fixes a solution dependency issue where Visual Studio wouldn't notice and rebuild changes in sub-projects like moonlight-common-c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Audio encryption is now enabled for streaming sessions, providing enhanced protection for audio data during transmission and playback.
  * Project dependencies have been configured to support the streaming application's stability and build integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->