### PR TITLE
Estimate RTP timestamps when not provided by the host

### DIFF
--- a/Streaming/FFmpegDecoder.h
+++ b/Streaming/FFmpegDecoder.h
@@ -73,5 +73,6 @@ class FFMpegDecoder {
 	int ffmpeg_buffer_size;
 	std::shared_ptr<DX::DeviceResources> m_deviceResources;
 	int m_LastFrameNumber;
+	int64_t m_StreamEpochQpc;
 };
 } // namespace moonlight_xbox_dx


### PR DESCRIPTION
Another fix for Wolf, which currently does not populate the RTP timestamp field for video packets. Xbox uses this for the host frametime graph and the display-locked frame pacer uses it to better pace frames. We can roughly work around this by setting the timestamps based on when the packet was received. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming decoder compatibility for sources that do not provide RTP timestamps. The decoder now automatically estimates missing timestamps to maintain proper stream synchronization and logs diagnostic warnings when estimation occurs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->