### PR TITLE
Update and expand README pertaining to locally building

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ A port of [Moonlight Stream](https://moonlight-stream.org/) for playing games us
 
 - Windows 10
 - Visual Studio 2022
+    - WinUI Application Development Workload
+        - Windows 10 SDK (10.0.19041.0) - This is marked as out of support as of VS 2022 version 17.10, but is still necessary for CMake
+        - Universal Windows Platform Tools
+        - C++ (v141, v142, v143) Universal Windows Platform Tools
 
 ### Steps to build
 

--- a/README.md
+++ b/README.md
@@ -64,5 +64,14 @@ A port of [Moonlight Stream](https://moonlight-stream.org/) for playing games us
     3. Install dependencies: `.\vcpkg\vcpkg.exe install --triplet x64-uwp`
 3. Run x64 Visual Studio Prompt (Tools → Command Line → Developer Command Prompt)
     1. Run `generate-thirdparty-projects.bat` to generate `moonlight-common-c` VS project
-    2. Go to `libgamestream` and run `build-uwp.bat` to generate `libgamestream` VS project
-4. After all the actions above, you finally can open and build solution.
+    2. Open `moonlight-xbox-dx.vcxproj` in Visual Studio 2022
+    3. In the solution explorer, right click and build each of these projects, in the following order:
+        - enet
+        - moonlight-common-c
+        - gamestream
+4. In the solution explorer, expand `moonlight-xbox-dx (Universal Windows)`, then double click `Package.appxmanifest`
+5. Under the `Packaging` tab, next to `Publisher`, click the `Choose Certificate` button
+    -If you already have a certificate, select it and skip to the final step
+6. In the `Choose a Certificate` window that appears, click the `Create...` button
+7. Fill out the create prompt which appears, password is unnecessary if only building for personal use and/or debugging purposes.
+8. After all the actions above, you can now build the entire solution.


### PR DESCRIPTION
Whilst attempting to build a distributable locally, I realized that the README instructions for a fresh install of UWP are outdated. Since I expended the time and effort necessary to get it working on my PC, I figured I would save everyone else the hour or so and update the doc myself. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Visual Studio 2022 build prerequisites to include the WinUI Application Development workload and specific Windows 10 SDK requirements.
  * Replaced automated build script with step-by-step Visual Studio workflow for building dependencies in specified order.
  * Added explicit packaging instructions for configuring manifest settings and certificate creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->