### PR TITLE
Test 120 FPS launch negotiation and presentation path

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -80,9 +80,9 @@ jobs:
         $hash = [System.BitConverter]::ToString($hashBytes).Replace("-", "").ToLower()
         $password = ConvertTo-SecureString -String $hash -Force -AsPlainText
 
-        # export the password for later use, decoded
-        $github_output = "password=$hash"
-        $github_output | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        # export the password and thumbprint for later use, decoded
+        "password=$hash" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "thumbprint=$($cert.Thumbprint)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
         Export-PfxCertificate `
           -Cert Cert:\LocalMachine\My\$($cert.Thumbprint) `
@@ -116,6 +116,7 @@ jobs:
       run: |
         # get the password from the output if this is a fork
         $certPassword = "${{ steps.cert.outputs.password }}"
+        $certThumbprint = "${{ steps.cert.outputs.thumbprint }}"
 
         # if certPassword is not empty, use it
         if ($certPassword -ne "") {
@@ -125,12 +126,20 @@ jobs:
           $certPasswordArg = ""
         }
 
+        if ($certThumbprint -ne "") {
+          $certThumbprintArg = "/p:PackageCertificateThumbprint=$certThumbprint"
+        }
+        else {
+          $certThumbprintArg = ""
+        }
+
         msbuild /m `
           /p:Configuration=${{env.BUILD_CONFIGURATION}} `
           /p:AppxBundle=Always `
           /p:AppxPackageDir=output `
           /p:PackageCertificateKeyFile=cert.pfx `
           /p:UapAppxPackageBuildMode=SideLoadOnly `
+          $certThumbprintArg `
           $certPasswordArg `
           ${{env.SOLUTION_FILE_PATH}}
 

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -55,8 +55,10 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       id: cert
       if: >-
-        github.event_name == 'pull_request' &&
-        !startsWith(github.event.pull_request.head.repo.full_name, 'TheElixZammuto/')
+        (github.event_name == 'pull_request' &&
+        !startsWith(github.event.pull_request.head.repo.full_name, 'TheElixZammuto/')) ||
+        (github.event_name == 'push' &&
+        !startsWith(github.repository, 'TheElixZammuto/'))
       run: |
         # generate a self signed certificate in pfx format
         

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -57,8 +57,8 @@ jobs:
       if: >-
         (github.event_name == 'pull_request' &&
         !startsWith(github.event.pull_request.head.repo.full_name, 'TheElixZammuto/')) ||
-        (github.event_name == 'push' &&
-        !startsWith(github.repository, 'TheElixZammuto/'))
+        (!startsWith(github.repository, 'TheElixZammuto/') &&
+        (github.event_name == 'push' || github.event_name == 'workflow_dispatch'))
       run: |
         # generate a self signed certificate in pfx format
         

--- a/Common/DeviceResources.cpp
+++ b/Common/DeviceResources.cpp
@@ -217,7 +217,7 @@ void DX::DeviceResources::CreateWindowSizeDependentResources()
 			lround(m_d3dRenderTargetSize.Width),
 			lround(m_d3dRenderTargetSize.Height),
 			m_backBufferFormat,
-			0
+			DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING
 			);
 
 		Utils::Logf("m_swapChain->ResizeBuffers(%d x %d)\n",
@@ -252,7 +252,8 @@ void DX::DeviceResources::CreateWindowSizeDependentResources()
 		//Check moonlight-stream/moonlight-qt/app/streaming/video/ffmpeg-renderers/d3d11va.cpp for rationale
 		swapChainDesc.BufferCount = 5;
 		swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
-		swapChainDesc.Flags = 0;
+		swapChainDesc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT
+		                    | DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
 		swapChainDesc.Scaling = DXGI_SCALING_STRETCH;
 		swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
 
@@ -292,6 +293,14 @@ void DX::DeviceResources::CreateWindowSizeDependentResources()
 		DX::ThrowIfFailed(
 			swapChain.As<IDXGISwapChain4>(&m_swapChain)
 		);
+
+		// Reduce frame queue latency to 1 so Present doesn't block behind stale frames.
+		// This is critical for 120 FPS on Xbox where the compositor otherwise throttles to 60 Hz.
+		ComPtr<IDXGISwapChain2> swapChain2;
+		if (SUCCEEDED(m_swapChain.As(&swapChain2))) {
+			swapChain2->SetMaximumFrameLatency(1);
+			Utils::Logf("SetMaximumFrameLatency(1) succeeded\n");
+		}
 
 		// Associate swap chain with SwapChainPanel
 		// UI changes will need to be dispatched back to the UI thread
@@ -525,7 +534,9 @@ void DX::DeviceResources::Trim()
 // Present the contents of the swap chain to the screen.
 void DX::DeviceResources::Present()
 {
-	HRESULT hr = m_swapChain->Present(0, 0);
+	// SyncInterval=0 + ALLOW_TEARING = no vsync, allows the render loop to
+	// run at the full target frame rate (120 FPS) without compositor throttling.
+	HRESULT hr = m_swapChain->Present(0, DXGI_PRESENT_ALLOW_TEARING);
 
 	// If the device was removed either by a disconnection or a driver upgrade, we
 	// must recreate all device resources.

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -756,11 +756,10 @@ int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, b
   uuid_generate_random(&uuid);
   uuid_unparse(&uuid, uuid_str);
   int surround_info = SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION(config->audioConfiguration);
-  // Using an FPS value over 60 causes SOPS to default to 720p60,
-  // so force it to 0 to ensure the correct resolution is set. We
-  // used to use 60 here but that locked the frame rate to 60 FPS
-  // on GFE 3.20.3.
-  int fps = (server->isNvidiaSoftware && config->fps > 60) ? 0 : config->fps;
+  // Preserve the requested FPS in the launch mode. Sending 0 for >60 FPS
+  // sessions can cause the host to start a 60 FPS stream even when the
+  // client requested 120 FPS.
+  int fps = config->fps;
   snprintf(url, sizeof(url), "https://%s:%u/%s?uniqueid=%s&uuid=%s&appid=%d&mode=%dx%dx%d&additionalStates=1&sops=%d&rikey=%s&rikeyid=%d&localAudioPlayMode=%d&surroundAudioInfo=%d&remoteControllersBitmap=%d&gcmap=%d%s%s",
       server->serverInfo.address, server->httpsPort, server->currentGame ? "resume" : "launch", unique_id, uuid_str, appId, config->width, config->height, fps, sops, rikey_hex, rikeyid, localaudio, surround_info, gamepad_mask, gamepad_mask,
       (config->supportedVideoFormats & VIDEO_FORMAT_MASK_10BIT) ? "&hdrMode=1&clientHdrCapVersion=0&clientHdrCapSupportedFlagsInUint32=0&clientHdrCapMetaDataId=NV_STATIC_METADATA_TYPE_1&clientHdrCapDisplayData=0x0x0x0x0x0x0x0x0x0x0" : "", LiGetLaunchUrlQueryParameters());


### PR DESCRIPTION
## Summary

Related to #269. This PR is a test build for the 120 FPS cap reported on Xbox.

## Possible fixes being tried

1. **Launch negotiation:** preserve the requested FPS in `libgamestream/client.c` when building the GameStream launch `mode=<width>x<height>x<fps>` parameter. The previous logic sent `0` for NVIDIA Software sessions above 60 FPS, which may cause the host to start a ~60 FPS session even when the client is configured for 120 FPS.

2. **Presentation latency:** try a lower-latency DXGI presentation path in `Common/DeviceResources.cpp` by enabling frame latency/tearing flags, setting maximum frame latency to 1, and presenting with `DXGI_PRESENT_ALLOW_TEARING`. This is intended to test whether the Xbox compositor path is throttling presentation around 60 Hz.

3. **Fork CI packaging:** update the workflow so fork `workflow_dispatch` builds generate a self-signed package cert and pass its thumbprint to MSBuild, allowing sideload artifacts to be produced for testing.

## Testing

A fork CI build is running here:
https://github.com/RobertPaulson90/moonlight-xbox/actions/runs/25240419015

This needs validation on Xbox Series X/S with the console output set to 120 Hz. In the stats overlay, the key things to compare are incoming FPS, decoding FPS, and rendering FPS.