### PR TITLE
Add periodic intra refreshes to mitigate HEVC errors

### DIFF
--- a/Pages/AppPage.xaml.cpp
+++ b/Pages/AppPage.xaml.cpp
@@ -171,6 +171,7 @@ void AppPage::Connect(int appId) {
 	config->framePacing = host->FramePacing;
 	config->enableStats = host->EnableStats;
 	config->enableGraphs = host->EnableGraphs;
+	config->idrInterval = host->IdrInterval;
 	if (config->enableHDR) {
 		host->VideoCodec = "HEVC (H.265)";
 	}

--- a/Pages/HostSettingsPage.xaml
+++ b/Pages/HostSettingsPage.xaml
@@ -40,6 +40,8 @@
                 <RowDefinition Height="auto"></RowDefinition>
                 <RowDefinition Height="auto"></RowDefinition>
                 <RowDefinition Height="auto"></RowDefinition>
+                <RowDefinition Height="auto"></RowDefinition>
+                <RowDefinition Height="auto"></RowDefinition>
             </Grid.RowDefinitions>
             <TextBlock Grid.Row="0" Grid.Column="0">Resolution</TextBlock>
             <ComboBox x:Name="ResolutionSelector" SelectionChanged="ResolutionSelector_SelectionChanged" SelectedIndex="{x:Bind CurrentResolutionIndex,Mode=TwoWay}" Grid.Row="0" Grid.Column="1" ItemsSource="{x:Bind AvailableResolutions}">
@@ -90,26 +92,33 @@
                 Best for Xbox One. Locks rendering frame rate to refresh rate and evenly spaces frames.
             </TextBlock>
 
-            <TextBlock Grid.Row="10" Grid.Column="0">Show performance stats:</TextBlock>
+            <TextBlock Grid.Row="10" Grid.Column="0" >Periodic decoder refresh:</TextBlock>
+                <CheckBox Name="EnableIdrIntervalCheckbox" Grid.Row="10" Grid.Column="1" Checked="EnableIdrIntervalCheckbox_Checked" Unchecked="EnableIdrIntervalCheckbox_Unchecked"></CheckBox>
+            <TextBlock Grid.Row="10" Grid.Column="2" >Mitigates HEVC corruption. Refreshes every (Target FPS)*(Interval) frames.</TextBlock>
+
+            <TextBlock Grid.Row="11" Grid.Column="0" >Refresh interval (Seconds)</TextBlock>
+            <Slider Name ="IdrIntervalSlider" Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" Value="{x:Bind Host.IdrInterval}" IsEnabled="False" x:DefaultBindMode="TwoWay" Minimum="2" Maximum="60" SmallChange="1" TickFrequency="2" StepFrequency="2" />
+
+            <TextBlock Grid.Row="12" Grid.Column="0">Show performance stats:</TextBlock>
             <CheckBox
-                Grid.Row="10" Grid.Column="1"
+                Grid.Row="12" Grid.Column="1"
                 x:Name="EnableStatsCheckbox"
                 IsChecked="{x:Bind Host.EnableStats, Mode=TwoWay}" />
 
-            <TextBlock Grid.Row="11" Grid.Column="0" >Show performance graphs:</TextBlock>
+            <TextBlock Grid.Row="13" Grid.Column="0" >Show performance graphs:</TextBlock>
             <CheckBox
-                Grid.Row="11" Grid.Column="1"
+                Grid.Row="13" Grid.Column="1"
                 x:Name="EnableGraphsCheckbox"
                 IsEnabled="{x:Bind Host.EnableStats, Mode=OneWay}"
                 IsChecked="{x:Bind Host.EnableGraphs, Mode=TwoWay}" />
             <TextBlock
-                Name="XboxOneGraphsNote" Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" Visibility="Collapsed">
+                Name="XboxOneGraphsNote" Grid.Row="13" Grid.Column="1" Grid.ColumnSpan="2" Visibility="Collapsed">
                 Graphs are unavailable on Xbox One when system resolution is set to 4K.
             </TextBlock>
 
-            <TextBlock Grid.Row="12" Grid.Column="0">Other:</TextBlock>
-            <Button Grid.Row="12" Grid.Column="1" x:Name="GlobalSettingsOption" Click="GlobalSettingsOption_Click">Open Global Settings</Button>
-        </Grid>
+            <TextBlock Grid.Row="14" Grid.Column="0">Other:</TextBlock>
+            <Button Grid.Row="14" Grid.Column="1" x:Name="GlobalSettingsOption" Click="GlobalSettingsOption_Click">Open Global Settings</Button>
+            </Grid>
     </StackPanel>
     </ScrollViewer>
 </Page>

--- a/Pages/HostSettingsPage.xaml.cpp
+++ b/Pages/HostSettingsPage.xaml.cpp
@@ -124,9 +124,11 @@ void HostSettingsPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEv
 
 	if (host->IdrInterval > 0) {
 		EnableIdrIntervalCheckbox->IsChecked = true;
+		IdrIntervalSlider->Minimum = 2;
 		IdrIntervalSlider->IsEnabled = true;
 	} else {
 		EnableIdrIntervalCheckbox->IsChecked = false;
+		IdrIntervalSlider->Minimum = 0;
 		IdrIntervalSlider->Value = 0;
 		IdrIntervalSlider->IsEnabled = false;
 	}

--- a/Pages/HostSettingsPage.xaml.cpp
+++ b/Pages/HostSettingsPage.xaml.cpp
@@ -204,8 +204,10 @@ void HostSettingsPage::FramePacing_SelectionChanged(Platform::Object^ sender, Wi
 
 void HostSettingsPage::EnableIdrIntervalCheckbox_Checked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e) {
 	IdrIntervalSlider->IsEnabled = true;
+	if (IdrIntervalSlider->Value < 2) {
+		IdrIntervalSlider->Value = 10;
+	}
 	IdrIntervalSlider->Minimum = 2;
-	IdrIntervalSlider->Value = 10;
 }
 
 void HostSettingsPage::EnableIdrIntervalCheckbox_Unchecked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e) {

--- a/Pages/HostSettingsPage.xaml.cpp
+++ b/Pages/HostSettingsPage.xaml.cpp
@@ -121,6 +121,15 @@ void HostSettingsPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEv
 			XboxOneGraphsNote->Visibility = Windows::UI::Xaml::Visibility::Collapsed;
 		}
 	}
+
+	if (host->IdrInterval > 0) {
+		EnableIdrIntervalCheckbox->IsChecked = true;
+		IdrIntervalSlider->IsEnabled = true;
+	} else {
+		EnableIdrIntervalCheckbox->IsChecked = false;
+		IdrIntervalSlider->Value = 0;
+		IdrIntervalSlider->IsEnabled = false;
+	}
 }
 
 void HostSettingsPage::backButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
@@ -189,6 +198,18 @@ void HostSettingsPage::FramePacing_SelectionChanged(Platform::Object^ sender, Wi
 	}
 
 	host->FramePacing = selectedFramePacing;
+}
+
+void HostSettingsPage::EnableIdrIntervalCheckbox_Checked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e) {
+	IdrIntervalSlider->IsEnabled = true;
+	IdrIntervalSlider->Minimum = 2;
+	IdrIntervalSlider->Value = 10;
+}
+
+void HostSettingsPage::EnableIdrIntervalCheckbox_Unchecked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e) {
+	IdrIntervalSlider->IsEnabled = false;
+	IdrIntervalSlider->Minimum = 0;
+	IdrIntervalSlider->Value = 0;
 }
 
 void HostSettingsPage::GlobalSettingsOption_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)

--- a/Pages/HostSettingsPage.xaml.h
+++ b/Pages/HostSettingsPage.xaml.h
@@ -110,6 +110,8 @@ namespace moonlight_xbox_dx
 		void BitrateInput_TextChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::TextChangedEventArgs^ e);
 		void AutoStartSelector_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e);
 		void FramePacing_SelectionChanged(Platform::Object^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs^ e);
+	    void EnableIdrIntervalCheckbox_Checked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+	    void EnableIdrIntervalCheckbox_Unchecked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 		void GlobalSettingsOption_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void BitrateInput_KeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
 		void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -51,6 +51,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
 					if (a.contains("serverAddress")) h->ServerAddress = Utils::StringFromStdString(a["serverAddress"].get<std::string>());
 					if (a.contains("macaddress")) h->MacAddress = Utils::StringFromStdString(a["macaddress"].get<std::string>());
 					else h->ComputerName = h->LastHostname;
+				    if (a.contains("idr_interval")) h->IdrInterval = a["idr_interval"];
 					this->SavedHosts->Append(h);
 				}
 			}
@@ -109,6 +110,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::UpdateFile()
 			hostJson["enable_stats"] = host->EnableStats;
 			hostJson["enable_graphs"] = host->EnableGraphs;
 			hostJson["serverAddress"] = Utils::PlatformStringToStdString(host->ServerAddress);
+			hostJson["idr_interval"] = host->IdrInterval;
 
 			std::string macAddr = Utils::PlatformStringToStdString(host->MacAddress);
 			if (macAddr != "00:00:00:00:00:00" && macAddr != "")

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -314,7 +314,7 @@ int MoonlightClient::StartStreaming(std::shared_ptr<DX::DeviceResources> res, St
 	callbacks.rumble = connection_rumble;
 	callbacks.rumbleTriggers = connection_trigger_rumble;
 
-	FFMpegDecoder::instance().CompleteInitialization(res, &config, sConfig->framePacing == "Immediate");
+	FFMpegDecoder::instance().CompleteInitialization(res, &config, sConfig->framePacing == "Immediate", sConfig->idrInterval);
 	DECODER_RENDERER_CALLBACKS rCallbacks = FFMpegDecoder::getDecoder();
 
 	AUDIO_RENDERER_CALLBACKS aCallbacks = AudioPlayer::getDecoder();

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -31,6 +31,7 @@ namespace moonlight_xbox_dx {
         bool enableSOPS = false;
         bool enableStats = false;
         bool enableGraphs = true;
+	    int idrInterval = 0;
         Windows::Foundation::Collections::IVector<MoonlightApp^>^ apps;
     public:
         //Thanks to https://phsucharee.wordpress.com/2013/06/19/data-binding-and-ccx-inotifypropertychanged/
@@ -284,5 +285,14 @@ namespace moonlight_xbox_dx {
                 OnPropertyChanged("EnableGraphs");
             }
         }
+
+        property int IdrInterval 
+        {
+		    int get() { return this->idrInterval; }
+		    void set(int value) {
+			    this->idrInterval = value;
+			    OnPropertyChanged("IdrInterval");
+		    }
+	    }
     };
 }

--- a/State/MoonlightHost.h
+++ b/State/MoonlightHost.h
@@ -290,7 +290,7 @@ namespace moonlight_xbox_dx {
         {
 		    int get() { return this->idrInterval; }
 		    void set(int value) {
-			    this->idrInterval = value;
+			    this->idrInterval = (value <= 0) ? 0 : (value < 2 ? 2 : value);
 			    OnPropertyChanged("IdrInterval");
 		    }
 	    }

--- a/State/StreamConfiguration.h
+++ b/State/StreamConfiguration.h
@@ -21,6 +21,7 @@ namespace moonlight_xbox_dx
 		property bool enableSOPS;
 		property bool enableStats;
 		property bool enableGraphs;
+	    property int idrInterval;
 	};
 
 	moonlight_xbox_dx::StreamConfiguration^ GetStreamConfig();

--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -281,7 +281,7 @@ namespace moonlight_xbox_dx {
 			}
 
 			// Request new IDR frames periodically to mitigate stream corruption.
-		    if (idrInterval > 0) {
+		    if (idrInterval > 0 && fps > 0) {
 			    if (frame->flags & AV_FRAME_FLAG_KEY) {
 				    m_FramesSinceIDR = 0;
 			    } else {

--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -85,9 +85,10 @@ namespace moonlight_xbox_dx {
 		Utils::Logf(shouldPrefixThisMessage ? "[ffmpeg] %s" : "%s", lineBuffer);
 	}
 
-    void FFMpegDecoder::CompleteInitialization(const std::shared_ptr<DX::DeviceResources>& res, STREAM_CONFIGURATION *config, bool framePacingImmediate) {
+    void FFMpegDecoder::CompleteInitialization(const std::shared_ptr<DX::DeviceResources>& res, STREAM_CONFIGURATION *config, bool framePacingImmediate, int idrInterval) {
 		this->m_deviceResources = res;
 		this->fps = config->fps;
+	    this->idrInterval = idrInterval;
 		Pacer::instance().init(res, config->fps, res->GetRefreshRate(), framePacingImmediate);
 	}
 
@@ -95,12 +96,11 @@ namespace moonlight_xbox_dx {
 		this->videoFormat = videoFormat;
 		this->width = width;
 		this->height = height;
-		this->fps = 60; // correctly set in CompleteInitialization
 
 		this->m_LastFrameNumber = 0;
 		this->ffmpeg_buffer_size = 0;
 		this->m_StreamEpochQpc = 0;
-
+	    this->m_FramesSinceIDR = 0;
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,10,100)
 		avcodec_register_all();
@@ -279,6 +279,20 @@ namespace moonlight_xbox_dx {
 				av_frame_free(&frame);
 				return DR_NEED_IDR;
 			}
+
+			// Request new IDR frames periodically to mitigate stream corruption.
+		    if (idrInterval > 0) {
+			    if (frame->pict_type == AV_PICTURE_TYPE_I) {
+				    m_FramesSinceIDR = 0;
+			    } else {
+				    m_FramesSinceIDR++;
+			    }
+
+			    if (m_FramesSinceIDR >= (fps * idrInterval)) {
+				    LiRequestIdrFrame();
+				    m_FramesSinceIDR = 0; // avoid requesting multiple IDR frames in a row
+			    }
+		    }
 
 			// Capture a frame timestamp to measuring pacing delay
 			QueryPerformanceCounter(&decodeEnd);

--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -282,7 +282,7 @@ namespace moonlight_xbox_dx {
 
 			// Request new IDR frames periodically to mitigate stream corruption.
 		    if (idrInterval > 0) {
-			    if (frame->pict_type == AV_PICTURE_TYPE_I) {
+			    if (frame->flags == AV_FRAME_FLAG_KEY) {
 				    m_FramesSinceIDR = 0;
 			    } else {
 				    m_FramesSinceIDR++;

--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -85,10 +85,10 @@ namespace moonlight_xbox_dx {
 		Utils::Logf(shouldPrefixThisMessage ? "[ffmpeg] %s" : "%s", lineBuffer);
 	}
 
-    void FFMpegDecoder::CompleteInitialization(const std::shared_ptr<DX::DeviceResources>& res, STREAM_CONFIGURATION *config, bool framePacingImmediate, int idrInterval) {
+	void FFMpegDecoder::CompleteInitialization(const std::shared_ptr<DX::DeviceResources>& res, STREAM_CONFIGURATION *config, bool framePacingImmediate, int idrInterval) {
 		this->m_deviceResources = res;
 		this->fps = config->fps;
-	    this->idrInterval = idrInterval;
+		this->idrInterval = idrInterval;
 		Pacer::instance().init(res, config->fps, res->GetRefreshRate(), framePacingImmediate);
 	}
 

--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -282,7 +282,7 @@ namespace moonlight_xbox_dx {
 
 			// Request new IDR frames periodically to mitigate stream corruption.
 		    if (idrInterval > 0) {
-			    if (frame->flags == AV_FRAME_FLAG_KEY) {
+			    if (frame->flags & AV_FRAME_FLAG_KEY) {
 				    m_FramesSinceIDR = 0;
 			    } else {
 				    m_FramesSinceIDR++;

--- a/Streaming/FFmpegDecoder.h
+++ b/Streaming/FFmpegDecoder.h
@@ -30,13 +30,13 @@ class FFMpegDecoder {
 	// Singleton accessor
 	static FFMpegDecoder &instance();
 
-	void CompleteInitialization(const std::shared_ptr<DX::DeviceResources> &res, STREAM_CONFIGURATION *config, bool framePacingImmediate);
+	void CompleteInitialization(const std::shared_ptr<DX::DeviceResources> &res, STREAM_CONFIGURATION *config, bool framePacingImmediate, int idrInterval);
 	int Init(int videoFormat, int width, int height, int redrawRate, void *context, int drFlags);
 	void Cleanup();
 	int SubmitDecodeUnit(PDECODE_UNIT decodeUnit);
 	static FFMpegDecoder *getInstance();
 	static DECODER_RENDERER_CALLBACKS getDecoder();
-	int videoFormat, width, height, fps;
+	int videoFormat, width, height, fps, idrInterval;
 	std::recursive_mutex m_mutex;
 
 	// locking helper
@@ -74,5 +74,6 @@ class FFMpegDecoder {
 	std::shared_ptr<DX::DeviceResources> m_deviceResources;
 	int m_LastFrameNumber;
 	int64_t m_StreamEpochQpc;
+	int m_FramesSinceIDR;
 };
 } // namespace moonlight_xbox_dx


### PR DESCRIPTION
Fix/Workaround for https://github.com/TheElixZammuto/moonlight-xbox/issues/190.

Requests IDR frames periodically to get rid of the video artifacts that keep accumulating when using HEVC.

Tested on my Series S against Apollo with a 9070 XT. 

<img width="1920" height="1080" alt="Screenshot_2026-05-10_06-28-04" src="https://github.com/user-attachments/assets/63999e27-fb90-44c0-b818-e5774609efe4" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Periodic decoder refresh" option in Host Settings with an enable/disable checkbox.
  * Added a slider to configure the decoder refresh interval when enabled.
  * Interval setting is persisted per host and applied automatically to streaming sessions.
  * Decoder now requests periodic keyframes according to the configured interval to improve stream consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheElixZammuto/moonlight-xbox/pull/274)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->