### PR TITLE
Fix HDR mode for virtual display

### DIFF
--- a/Streaming/VideoRenderer.cpp
+++ b/Streaming/VideoRenderer.cpp
@@ -159,30 +159,53 @@ bool VideoRenderer::Render(AVFrame *frame) {
 	ID3D11ShaderResourceView* nullSrvs[2] = {};
 	ctx->PSSetShaderResources(0, 2, nullSrvs);
 
-	if (frame->color_trc != m_LastColorTrc) {
-		DXGI_COLOR_SPACE_TYPE colorspace = {};
-
-		if (frame->color_trc == AVCOL_TRC_SMPTE2084) {
-			// Switch to Rec 2020 PQ (SMPTE ST 2084) colorspace for HDR10 rendering
-			colorspace = DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
-		} else {
-			// Restore default sRGB colorspace
-			colorspace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
-		}
-
-		UINT colorSpaceSupport = 0;
-		if (colorspace && SUCCEEDED(m_deviceResources->GetSwapChain()->CheckColorSpaceSupport(colorspace, &colorSpaceSupport)) && (colorSpaceSupport & DXGI_SWAP_CHAIN_COLOR_SPACE_SUPPORT_FLAG_PRESENT)) {
-			DX::ThrowIfFailed(m_deviceResources->GetSwapChain()->SetColorSpace1(colorspace));
-			Utils::Logf("Colorspace changed to %s\n",
-			            colorspace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
-			                ? "DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020"
-			                : "DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709");
-		}
-
-		m_LastColorTrc = frame->color_trc;
-	}
+	applySwapChainColorSpace(frame);
 
 	return true;
+}
+
+bool VideoRenderer::frameUsesHdrColorSpace(const AVFrame* frame) const {
+	if (frame->color_trc == AVCOL_TRC_SMPTE2084) {
+		return true;
+	}
+
+	if (!configuration->enableHDR && !client->IsHDR()) {
+		return false;
+	}
+
+	// HDR stream or display: HEVC Main10 often omits TRC or reports BT.709 despite PQ content
+	return frame->color_trc == AVCOL_TRC_UNSPECIFIED || frame->color_trc == AVCOL_TRC_BT709;
+}
+
+void VideoRenderer::applySwapChainColorSpace(const AVFrame* frame) {
+	bool useHdr = frameUsesHdrColorSpace(frame);
+	if (useHdr == m_SwapChainHdrColorSpace && frame->color_trc == m_LastColorTrc) {
+		return;
+	}
+
+	auto* swapChain = m_deviceResources->GetSwapChain();
+	if (!swapChain) {
+		return;
+	}
+
+	DXGI_COLOR_SPACE_TYPE colorspace = useHdr
+	    ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
+	    : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+
+	HRESULT hr = swapChain->SetColorSpace1(colorspace);
+	if (SUCCEEDED(hr)) {
+		Utils::Logf("Colorspace changed to %s (color_trc=%d, hdrStream=%d, displayHdr=%d)\n",
+		            useHdr ? "DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020"
+		                   : "DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709",
+		            frame->color_trc, configuration->enableHDR, client->IsHDR());
+		m_SwapChainHdrColorSpace = useHdr;
+		m_LastColorTrc = frame->color_trc;
+	} else {
+		Utils::Logf("SetColorSpace1(%s) failed: 0x%08X (color_trc=%d)\n",
+		            useHdr ? "DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020"
+		                   : "DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709",
+		            hr, frame->color_trc);
+	}
 }
 
 void VideoRenderer::CreateDeviceDependentResources()
@@ -680,6 +703,30 @@ void VideoRenderer::SetHDR(bool enabled)
 	else {
 		// toggle the display to the correct state
 		client->SetDisplayHDR(false, SS_HDR_METADATA{});
+	}
+
+	// Keep HDMI and swap chain color spaces in sync; force re-apply on next frame if this fails
+	m_LastColorTrc = AVCOL_TRC_UNSPECIFIED;
+	m_SwapChainHdrColorSpace = !enabled;
+
+	auto* swapChain = m_deviceResources->GetSwapChain();
+	if (!swapChain) {
+		return;
+	}
+
+	DXGI_COLOR_SPACE_TYPE colorspace = enabled
+	    ? DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
+	    : DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+
+	HRESULT hr = swapChain->SetColorSpace1(colorspace);
+	if (SUCCEEDED(hr)) {
+		m_SwapChainHdrColorSpace = enabled;
+		Utils::Logf("SetHDR(%s): swap chain colorspace set to %s\n",
+		            enabled ? "true" : "false",
+		            enabled ? "DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020"
+		                    : "DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709");
+	} else {
+		Utils::Logf("SetHDR(%s): SetColorSpace1 failed: 0x%08X\n", enabled ? "true" : "false", hr);
 	}
 }
 

--- a/Streaming/VideoRenderer.h
+++ b/Streaming/VideoRenderer.h
@@ -55,6 +55,8 @@ namespace moonlight_xbox_dx
 		void getFramePremultipliedCscConstants(const AVFrame* frame, std::array<float, 9> &cscMatrix, std::array<float, 3> &offsets);
 		void getFrameChromaCositingOffsets(const AVFrame* frame, std::array<float, 2> &chromaOffsets);
 		bool hasFrameFormatChanged(const AVFrame* frame);
+		bool frameUsesHdrColorSpace(const AVFrame* frame) const;
+		void applySwapChainColorSpace(const AVFrame* frame);
 
 		// Cached pointer to device resources.
 		std::shared_ptr<DX::DeviceResources> m_deviceResources;
@@ -97,6 +99,7 @@ namespace moonlight_xbox_dx
 		AVColorTransferCharacteristic m_LastColorTrc = AVCOL_TRC_UNSPECIFIED;
 		AVColorSpace m_LastColorSpace = AVCOL_SPC_UNSPECIFIED;
 		AVChromaLocation m_LastChromaLocation = AVCHROMA_LOC_UNSPECIFIED;
+		bool m_SwapChainHdrColorSpace = false;
 	};
 }
 


### PR DESCRIPTION
It is a possible fix for the HDR issue reported here: https://github.com/TheElixZammuto/moonlight-xbox/issues/234 

As I've never done any C++ programming (but have worked with a bunch of other languages over the last 15 years), I rely on Cursor for the proposed changes, with the following explanations of possible HDR issues.

I've published the project and tested via Dev Mode on my Xbox; HDR works fine.


**Both reasons and fixes seem reasonable. I am not an expert, and if the changes don't make sense, so be it. I hope these proposed changes will help to fix HDR issues properly.**

### Reason 1

Swap chain color space never set to PQ (highest probability)
The swap chain defaults to sRGB/gamma 2.2 for R10G10B10A2. HDR10 requires explicitly setting DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020.
Problems:

- CheckColorSpaceSupport can fail silently — if it fails, nothing is logged and m_LastColorTrc is still updated, so it never retries.
- Only triggers when color_trc == AVCOL_TRC_SMPTE2084 — if FFmpeg leaves color_trc as UNSPECIFIED or BT709 on HDR frames, the swap chain stays in SDR mode while PQ content is drawn.
- moonlight-qt does not use CheckColorSpaceSupport — it calls SetColorSpace1 directly and logs HRESULT on failure.
- Symptom: TV in HDR mode, PQ pixel data presented as sRGB → classic washed-out, overly bright HDR look.

Fix:

- Call SetColorSpace1 directly (like moonlight-qt) and log failures.
- When HDR is active (configuration->enableHDR or client->IsHDR()), treat UNSPECIFIED/BT709 as PQ for swap chain purposes.
- Reset m_LastColorTrc when enabling HDR so the next frame re-applies color space.



### Reason 2

HDMI HDR enabled, but rendering path still SDR (timing / coordination)
SetDisplayHDR (HDMI) and SetColorSpace1 (swap chain) are triggered separately:

- HDMI: SetHDR callback → VideoRenderer::SetHDR → SetDisplayHDR
- Swap chain: per-frame in Render() based on frame->color_trc

SetHDR waits for loading to finish; frames can render before HDMI switches or before swap chain color space is set.

There is also a known issue in the project TODO:

> "When changing the Windows HDR calibration profile on the host, it causes the stream to reset and often switch to the wrong colorspace."

Fix:

- Set swap chain color space inside SetHDR(true), not only from frame metadata.
- Reset m_LastColorTrc when toggling HDR so color space is re-applied on the next frame.
- After ResizeBuffers / device lost, color space resets to default — force re-apply (reset m_LastColorTrc on swap chain recreate).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video color handling so the display updates more reliably when switching between HDR and SDR content.
  * Kept HDR settings and the video output in sync, reducing cases where colors could appear incorrect after a mode change.
  * Added more robust logging around color-space updates to help detect and recover from display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->