### PR TITLE
Add protocol activation support for Frontends

### DIFF
--- a/App.xaml.cpp
+++ b/App.xaml.cpp
@@ -8,6 +8,9 @@
 #include "MoonlightWelcome.xaml.h"
 #include "Pages\StreamPage.xaml.h"
 
+#include <cerrno>
+#include <climits>
+
 using namespace moonlight_xbox_dx;
 
 using namespace Platform;
@@ -35,6 +38,56 @@ App::App()
 	Suspending += ref new SuspendingEventHandler(this, &App::OnSuspending);
 	Resuming += ref new EventHandler<Object^>(this, &App::OnResuming);
 	displayRequest = ref new Windows::System::Display::DisplayRequest();
+}
+
+void App::InitializeState()
+{
+	if (m_stateLoaded) {
+		if (m_menuPage != nullptr) {
+			m_menuPage->OnStateLoaded();
+		}
+		return;
+	}
+
+	if (m_initStarted) {
+		return;
+	}
+
+	m_initStarted = true;
+	auto that = this;
+	try {
+		m_initTask = GetApplicationState()->Init();
+	}
+	catch (const std::exception& ex) {
+		m_initStarted = false;
+		moonlight_xbox_dx::Utils::Logf("Application state initialization exception: %s\n", ex.what());
+		return;
+	}
+	catch (...) {
+		m_initStarted = false;
+		moonlight_xbox_dx::Utils::Log("Application state initialization unknown exception\n");
+		return;
+	}
+
+	m_initTask.then([that](Concurrency::task<void> initTask) {
+		try {
+			initTask.get();
+			that->m_stateLoaded = true;
+			if (that->m_menuPage != nullptr) {
+				that->m_menuPage->OnStateLoaded();
+			}
+		}
+		catch (const std::exception& ex) {
+			that->m_initStarted = false;
+			moonlight_xbox_dx::Utils::Logf("Application state initialization exception: %s\n", ex.what());
+			return;
+		}
+		catch (...) {
+			that->m_initStarted = false;
+			moonlight_xbox_dx::Utils::Log("Application state initialization unknown exception\n");
+			return;
+		}
+	}, Concurrency::task_continuation_context::get_current_winrt_context());
 }
 
 /// <summary>
@@ -82,18 +135,11 @@ void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEvent
 	}
 	// Ensure the current window is active
 	Window::Current->Activate();
-	//Start the state
-	auto state = GetApplicationState();
-	auto that = this;
-	state->Init().then([that](){
-		that->m_stateLoaded = true;
-		that->m_menuPage->OnStateLoaded();
-	});
+	InitializeState();
 	displayRequest->RequestActive();
 }
 
 namespace {
-	// Parsed from a protocol activation, e.g. moonlight:?host=192.168.1.10&appName=Desktop&launchOnExit=retropass:
 	struct ProtocolLaunchRequest {
 		bool hasTarget = false;
 		std::wstring host;
@@ -104,7 +150,6 @@ namespace {
 		Platform::String^ launchOnExit;
 	};
 
-	// Flag-style parameters count as enabled when present without a value
 	bool IsTruthyParam(Platform::String^ value) {
 		if (value == nullptr || value->IsEmpty()) return true;
 		return _wcsicmp(value->Data(), L"true") == 0 || _wcsicmp(value->Data(), L"1") == 0 || _wcsicmp(value->Data(), L"yes") == 0;
@@ -130,8 +175,16 @@ namespace {
 				request.host = value->Data();
 				request.hasTarget = true;
 			} else if (_wcsicmp(name, L"appId") == 0 && hasValue) {
-				request.appId = (int)wcstol(value->Data(), nullptr, 10);
-				request.hasTarget = true;
+				wchar_t* end = nullptr;
+				const wchar_t* begin = value->Data();
+				errno = 0;
+				long parsed = wcstol(begin, &end, 10);
+				if (errno != ERANGE && end != begin && *end == L'\0' && parsed > 0 && parsed <= INT_MAX) {
+					request.appId = static_cast<int>(parsed);
+					request.hasTarget = true;
+				} else {
+					moonlight_xbox_dx::Utils::Log("Protocol activation: ignoring invalid appId\n");
+				}
 			} else if (_wcsicmp(name, L"appName") == 0 && hasValue) {
 				request.appName = value->Data();
 				request.hasTarget = true;
@@ -146,7 +199,6 @@ namespace {
 					request.hasTarget = true;
 				}
 			} else if (_wcsicmp(name, L"launchOnExit") == 0 && hasValue) {
-				// Return URI provided by the launching frontend (e.g. "retropass:"), passed through as-is
 				request.launchOnExit = value;
 				request.hasLaunchOnExit = true;
 			}
@@ -155,9 +207,6 @@ namespace {
 	}
 }
 
-/// <summary>
-/// Invoked when the application is activated through a URI scheme (moonlight:).
-/// </summary>
 void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e)
 {
 	if (e->Kind != Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
@@ -180,7 +229,6 @@ void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs
 		Window::Current->Content = rootFrame;
 	}
 
-	// Never interrupt an active streaming session, just bring the window to the foreground
 	if (dynamic_cast<StreamPage^>(rootFrame->Content) != nullptr) {
 		moonlight_xbox_dx::Utils::Log("Protocol activation ignored: a stream is currently active\n");
 		Window::Current->Activate();
@@ -188,33 +236,39 @@ void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs
 	}
 
 	auto state = GetApplicationState();
+	state->pendingProtocolHostSelect = false;
+	state->pendingProtocolHost.clear();
+	state->pendingProtocolAppId = -1;
+	state->pendingProtocolAppName.clear();
+	state->pendingProtocolResume = false;
+	state->launchOnExitUri = nullptr;
+
+	if (!rootFrame->Navigate(TypeName(HostSelectorPage::typeid))) {
+		moonlight_xbox_dx::Utils::Log("Protocol activation: navigation to HostSelectorPage failed\n");
+		Window::Current->Activate();
+		return;
+	}
+	rootFrame->BackStack->Clear();
+	m_menuPage = dynamic_cast<HostSelectorPage^>(rootFrame->Content);
+	if (m_menuPage == nullptr) {
+		moonlight_xbox_dx::Utils::Log("Protocol activation: HostSelectorPage instance unavailable\n");
+		Window::Current->Activate();
+		return;
+	}
+
 	state->pendingProtocolHostSelect = request.hasTarget;
 	state->pendingProtocolHost = request.host;
 	state->pendingProtocolAppId = request.appId;
 	state->pendingProtocolAppName = request.appName;
 	state->pendingProtocolResume = request.resume;
-	if (request.hasLaunchOnExit) {
-		state->launchOnExitUri = request.launchOnExit;
-	}
-
-	rootFrame->Navigate(TypeName(HostSelectorPage::typeid));
-	rootFrame->BackStack->Clear();
-	m_menuPage = dynamic_cast<HostSelectorPage^>(rootFrame->Content);
+	state->launchOnExitUri = request.hasTarget && request.hasLaunchOnExit ? request.launchOnExit : nullptr;
 
 	Window::Current->Activate();
 	if (isColdStart) {
 		displayRequest->RequestActive();
 	}
 
-	auto that = this;
-	if (!m_stateLoaded) {
-		state->Init().then([that]() {
-			that->m_stateLoaded = true;
-			that->m_menuPage->OnStateLoaded();
-		});
-	} else {
-		m_menuPage->OnStateLoaded();
-	}
+	InitializeState();
 }
 /// <summary>
 /// Invoked when application execution is being suspended.  Application state is saved

--- a/App.xaml.cpp
+++ b/App.xaml.cpp
@@ -6,6 +6,7 @@
 #include "pch.h"
 #include <Utils.hpp>
 #include "MoonlightWelcome.xaml.h"
+#include "Pages\StreamPage.xaml.h"
 
 using namespace moonlight_xbox_dx;
 
@@ -85,9 +86,135 @@ void App::OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEvent
 	auto state = GetApplicationState();
 	auto that = this;
 	state->Init().then([that](){
+		that->m_stateLoaded = true;
 		that->m_menuPage->OnStateLoaded();
 	});
 	displayRequest->RequestActive();
+}
+
+namespace {
+	// Parsed from a protocol activation, e.g. moonlight:?host=192.168.1.10&appName=Desktop&launchOnExit=retropass:
+	struct ProtocolLaunchRequest {
+		bool hasTarget = false;
+		std::wstring host;
+		int appId = -1;
+		std::wstring appName;
+		bool resume = false;
+		bool hasLaunchOnExit = false;
+		Platform::String^ launchOnExit;
+	};
+
+	// Flag-style parameters count as enabled when present without a value
+	bool IsTruthyParam(Platform::String^ value) {
+		if (value == nullptr || value->IsEmpty()) return true;
+		return _wcsicmp(value->Data(), L"true") == 0 || _wcsicmp(value->Data(), L"1") == 0 || _wcsicmp(value->Data(), L"yes") == 0;
+	}
+
+	ProtocolLaunchRequest ParseProtocolUri(Windows::Foundation::Uri^ uri) {
+		ProtocolLaunchRequest request;
+		Windows::Foundation::WwwFormUrlDecoder^ query = nullptr;
+		try {
+			query = uri->QueryParsed;
+		} catch (...) {
+			moonlight_xbox_dx::Utils::Log("Protocol activation: failed to parse query string\n");
+			return request;
+		}
+		if (query == nullptr) return request;
+		for (unsigned int i = 0; i < query->Size; i++) {
+			auto entry = query->GetAt(i);
+			if (entry == nullptr || entry->Name == nullptr) continue;
+			const wchar_t* name = entry->Name->Data();
+			Platform::String^ value = entry->Value;
+			bool hasValue = value != nullptr && !value->IsEmpty();
+			if (_wcsicmp(name, L"host") == 0 && hasValue) {
+				request.host = value->Data();
+				request.hasTarget = true;
+			} else if (_wcsicmp(name, L"appId") == 0 && hasValue) {
+				request.appId = (int)wcstol(value->Data(), nullptr, 10);
+				request.hasTarget = true;
+			} else if (_wcsicmp(name, L"appName") == 0 && hasValue) {
+				request.appName = value->Data();
+				request.hasTarget = true;
+			} else if (_wcsicmp(name, L"desktop") == 0) {
+				if (IsTruthyParam(value)) {
+					request.appName = L"Desktop";
+					request.hasTarget = true;
+				}
+			} else if (_wcsicmp(name, L"resume") == 0) {
+				if (IsTruthyParam(value)) {
+					request.resume = true;
+					request.hasTarget = true;
+				}
+			} else if (_wcsicmp(name, L"launchOnExit") == 0 && hasValue) {
+				// Return URI provided by the launching frontend (e.g. "retropass:"), passed through as-is
+				request.launchOnExit = value;
+				request.hasLaunchOnExit = true;
+			}
+		}
+		return request;
+	}
+}
+
+/// <summary>
+/// Invoked when the application is activated through a URI scheme (moonlight:).
+/// </summary>
+void App::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e)
+{
+	if (e->Kind != Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
+		return;
+	}
+	auto protocolArgs = dynamic_cast<Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs^>(e);
+	if (protocolArgs == nullptr || protocolArgs->Uri == nullptr) {
+		return;
+	}
+	moonlight_xbox_dx::Utils::Logf("Protocol activation: %S\n", protocolArgs->Uri->AbsoluteUri->Data());
+
+	ProtocolLaunchRequest request = ParseProtocolUri(protocolArgs->Uri);
+
+	auto rootFrame = dynamic_cast<Frame^>(Window::Current->Content);
+	bool isColdStart = (rootFrame == nullptr);
+	if (rootFrame == nullptr)
+	{
+		rootFrame = ref new Frame();
+		rootFrame->NavigationFailed += ref new Windows::UI::Xaml::Navigation::NavigationFailedEventHandler(this, &App::OnNavigationFailed);
+		Window::Current->Content = rootFrame;
+	}
+
+	// Never interrupt an active streaming session, just bring the window to the foreground
+	if (dynamic_cast<StreamPage^>(rootFrame->Content) != nullptr) {
+		moonlight_xbox_dx::Utils::Log("Protocol activation ignored: a stream is currently active\n");
+		Window::Current->Activate();
+		return;
+	}
+
+	auto state = GetApplicationState();
+	state->pendingProtocolHostSelect = request.hasTarget;
+	state->pendingProtocolHost = request.host;
+	state->pendingProtocolAppId = request.appId;
+	state->pendingProtocolAppName = request.appName;
+	state->pendingProtocolResume = request.resume;
+	if (request.hasLaunchOnExit) {
+		state->launchOnExitUri = request.launchOnExit;
+	}
+
+	rootFrame->Navigate(TypeName(HostSelectorPage::typeid));
+	rootFrame->BackStack->Clear();
+	m_menuPage = dynamic_cast<HostSelectorPage^>(rootFrame->Content);
+
+	Window::Current->Activate();
+	if (isColdStart) {
+		displayRequest->RequestActive();
+	}
+
+	auto that = this;
+	if (!m_stateLoaded) {
+		state->Init().then([that]() {
+			that->m_stateLoaded = true;
+			that->m_menuPage->OnStateLoaded();
+		});
+	} else {
+		m_menuPage->OnStateLoaded();
+	}
 }
 /// <summary>
 /// Invoked when application execution is being suspended.  Application state is saved

--- a/App.xaml.h
+++ b/App.xaml.h
@@ -18,6 +18,7 @@ namespace moonlight_xbox_dx
 	public:
 		App();
 		virtual void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs^ e) override;
+		virtual void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e) override;
 		void OnStateLoaded();
 	private:
 		void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
@@ -25,5 +26,6 @@ namespace moonlight_xbox_dx
 		void OnNavigationFailed(Platform::Object ^sender, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs ^e);
 		HostSelectorPage^ m_menuPage;
 		Windows::System::Display::DisplayRequest^ displayRequest;
+		bool m_stateLoaded = false;
 	};
 }

--- a/App.xaml.h
+++ b/App.xaml.h
@@ -21,11 +21,14 @@ namespace moonlight_xbox_dx
 		virtual void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs^ e) override;
 		void OnStateLoaded();
 	private:
+		void InitializeState();
 		void OnSuspending(Platform::Object^ sender, Windows::ApplicationModel::SuspendingEventArgs^ e);
 		void OnResuming(Platform::Object ^sender, Platform::Object ^args);
 		void OnNavigationFailed(Platform::Object ^sender, Windows::UI::Xaml::Navigation::NavigationFailedEventArgs ^e);
 		HostSelectorPage^ m_menuPage;
 		Windows::System::Display::DisplayRequest^ displayRequest;
+		bool m_initStarted = false;
 		bool m_stateLoaded = false;
+		Concurrency::task<void> m_initTask;
 	};
 }

--- a/Package.appxmanifest
+++ b/Package.appxmanifest
@@ -41,6 +41,13 @@
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" Square71x71Logo="Assets\SmallTile.png" Square310x310Logo="Assets\LargeTile.png"/>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="moonlight">
+            <uap:DisplayName>Moonlight UWP</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
 

--- a/Pages/AppPage.xaml.cpp
+++ b/Pages/AppPage.xaml.cpp
@@ -118,7 +118,44 @@ void AppPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ 
 		}
 	});
 
-	if (host->AutostartID >= 0 && GetApplicationState()->shouldAutoConnect) {
+	auto state = GetApplicationState();
+	bool hasProtocolRequest = state->pendingProtocolAppId >= 0 || !state->pendingProtocolAppName.empty() || state->pendingProtocolResume;
+	if (hasProtocolRequest) {
+		int requestedAppId = state->pendingProtocolAppId;
+		std::wstring requestedAppName = state->pendingProtocolAppName;
+		bool resumeRequested = state->pendingProtocolResume;
+		state->pendingProtocolAppId = -1;
+		state->pendingProtocolAppName.clear();
+		state->pendingProtocolResume = false;
+
+		// Dispatched at High priority so this runs after UpdateApps() has filled the Apps list
+		Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(
+			Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([this, requestedAppId, requestedAppName, resumeRequested]() {
+				int targetId = -1;
+				if (resumeRequested && host->CurrentlyRunningAppId != 0) {
+					targetId = host->CurrentlyRunningAppId;
+				}
+				if (targetId < 0 && requestedAppId >= 0) {
+					targetId = requestedAppId;
+				}
+				if (targetId < 0 && !requestedAppName.empty()) {
+					for (unsigned int i = 0; i < host->Apps->Size; ++i) {
+						auto app = host->Apps->GetAt(i);
+						if (app != nullptr && app->Name != nullptr && _wcsicmp(app->Name->Data(), requestedAppName.c_str()) == 0) {
+							targetId = app->Id;
+							break;
+						}
+					}
+					if (targetId < 0) {
+						Utils::Log("Protocol activation: no app matched the requested name, staying on the app list\n");
+					}
+				}
+				if (targetId >= 0) {
+					this->Connect(targetId);
+				}
+			}));
+	}
+	else if (host->AutostartID >= 0 && GetApplicationState()->shouldAutoConnect) {
 		GetApplicationState()->shouldAutoConnect = false;
 		Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(
 			Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([this]() {

--- a/Pages/AppPage.xaml.cpp
+++ b/Pages/AppPage.xaml.cpp
@@ -128,7 +128,6 @@ void AppPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ 
 		state->pendingProtocolAppName.clear();
 		state->pendingProtocolResume = false;
 
-		// Dispatched at High priority so this runs after UpdateApps() has filled the Apps list
 		Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(
 			Windows::UI::Core::CoreDispatcherPriority::High, ref new Windows::UI::Core::DispatchedHandler([this, requestedAppId, requestedAppName, resumeRequested]() {
 				int targetId = -1;

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -223,6 +223,10 @@ void HostSelectorPage::OnStateLoaded() {
 			a->UpdateHostInfo(false);
 		}
 	}).then([this]() {
+		if (GetApplicationState()->pendingProtocolHostSelect) {
+			this->HandleProtocolHostSelect();
+			return;
+		}
 		if (GetApplicationState()->autostartInstance.size() > 0) {
 			auto pii = Utils::StringFromStdString(GetApplicationState()->autostartInstance);
 			for (unsigned int i = 0; i < GetApplicationState()->SavedHosts->Size; i++) {
@@ -250,6 +254,62 @@ void HostSelectorPage::OnStateLoaded() {
 			Utils::Log("HostSelectorPage OnStateLoaded task unknown exception");
 		}
 	});
+}
+
+// The host query can match the instance id, the computer name or the hostname/IP
+void HostSelectorPage::HandleProtocolHostSelect() {
+	auto state = GetApplicationState();
+	state->pendingProtocolHostSelect = false;
+	std::wstring query = state->pendingProtocolHost;
+
+	MoonlightHost^ target = nullptr;
+	if (query.empty()) {
+		if (state->SavedHosts->Size == 1) {
+			target = state->SavedHosts->GetAt(0);
+		}
+		else if (state->autostartInstance.size() > 0) {
+			auto pii = Utils::StringFromStdString(state->autostartInstance);
+			for (unsigned int i = 0; i < state->SavedHosts->Size; i++) {
+				auto host = state->SavedHosts->GetAt(i);
+				if (host->InstanceId != nullptr && host->InstanceId->Equals(pii)) {
+					target = host;
+					break;
+				}
+			}
+		}
+	}
+	else {
+		auto matches = [&query](Platform::String^ value) {
+			return value != nullptr && _wcsicmp(value->Data(), query.c_str()) == 0;
+		};
+		for (unsigned int i = 0; i < state->SavedHosts->Size; i++) {
+			auto host = state->SavedHosts->GetAt(i);
+			if (matches(host->InstanceId) || matches(host->ComputerName) || matches(host->LastHostname)) {
+				target = host;
+				break;
+			}
+		}
+	}
+
+	// Drop the pending app request too, so it doesn't leak into a later manual host selection
+	if (target == nullptr || !target->Connected) {
+		Utils::Log(target == nullptr
+			? "Protocol activation: no saved host matched the requested host\n"
+			: "Protocol activation: the requested host is not reachable\n");
+		state->pendingProtocolAppId = -1;
+		state->pendingProtocolAppName.clear();
+		state->pendingProtocolResume = false;
+		return;
+	}
+
+	auto that = this;
+	MoonlightHost^ host = target;
+	Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(
+		Windows::UI::Core::CoreDispatcherPriority::High,
+		ref new Windows::UI::Core::DispatchedHandler([that, host]() {
+			that->Connect(host);
+		})
+	);
 }
 
 void HostSelectorPage::Connect(MoonlightHost^ host) {

--- a/Pages/HostSelectorPage.xaml.cpp
+++ b/Pages/HostSelectorPage.xaml.cpp
@@ -243,7 +243,7 @@ void HostSelectorPage::OnStateLoaded() {
 				}
 			}
 		}
-	}).then([this](concurrency::task<void> t) {
+	}, Concurrency::task_continuation_context::get_current_winrt_context()).then([this](concurrency::task<void> t) {
 		try {
 			t.get();
 		}
@@ -256,7 +256,6 @@ void HostSelectorPage::OnStateLoaded() {
 	});
 }
 
-// The host query can match the instance id, the computer name or the hostname/IP
 void HostSelectorPage::HandleProtocolHostSelect() {
 	auto state = GetApplicationState();
 	state->pendingProtocolHostSelect = false;
@@ -291,14 +290,21 @@ void HostSelectorPage::HandleProtocolHostSelect() {
 		}
 	}
 
-	// Drop the pending app request too, so it doesn't leak into a later manual host selection
 	if (target == nullptr || !target->Connected) {
 		Utils::Log(target == nullptr
 			? "Protocol activation: no saved host matched the requested host\n"
 			: "Protocol activation: the requested host is not reachable\n");
+		ContentDialog^ dialog = ref new ContentDialog();
+		dialog->Title = "Protocol Launch Failed";
+		dialog->Content = target == nullptr
+			? "No saved host matched the requested host."
+			: "The requested host is not reachable.";
+		dialog->PrimaryButtonText = "OK";
+		concurrency::create_task(::moonlight_xbox_dx::ModalDialog::ShowOnceAsync(dialog));
 		state->pendingProtocolAppId = -1;
 		state->pendingProtocolAppName.clear();
 		state->pendingProtocolResume = false;
+		state->launchOnExitUri = nullptr;
 		return;
 	}
 

--- a/Pages/HostSelectorPage.xaml.h
+++ b/Pages/HostSelectorPage.xaml.h
@@ -45,6 +45,7 @@ namespace moonlight_xbox_dx
 		void SettingsButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		std::atomic<bool> continueFetch;
 		void OnKeyDown(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
+		void HandleProtocolHostSelect();
 		void wakeHostButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void testConnectionButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void ShowHostActions(Windows::UI::Xaml::FrameworkElement^ anchor, MoonlightHost^ host);

--- a/Pages/StreamPage.xaml.cpp
+++ b/Pages/StreamPage.xaml.cpp
@@ -9,7 +9,6 @@
 #include "../Streaming/FFMpegDecoder.h"
 #include <Utils.hpp>
 #include <KeyboardControl.xaml.h>
-#include "../Common/ModalDialog.xaml.h"
 
 using namespace moonlight_xbox_dx;
 
@@ -262,37 +261,18 @@ void StreamPage::OnKeyUp(Windows::UI::Core::CoreWindow^ sender, Windows::UI::Cor
 }
 
 void StreamPage::disconnectAndCloseButton_Click(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e) {
-	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown -= keyDownHandler;
-	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyUp -= keyUpHandler;
-	if (this->m_main) {
-		// trigger the server disconnected flow which will cleanly exit the loop and call StopRenderLoop()
-		this->m_main->moonlightClient->SetConnectionTerminated();
+	if (this->m_main == nullptr) {
+		return;
 	}
 
-	auto that = this;
+	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyDown -= keyDownHandler;
+	Windows::UI::Core::CoreWindow::GetForCurrentThread()->KeyUp -= keyUpHandler;
 
-	auto progressToken = ::moonlight_xbox_dx::ModalDialog::ShowProgressDialogToken(nullptr, Utils::StringFromStdString("Closing..."));
+	this->m_progressView->Visibility = Windows::UI::Xaml::Visibility::Visible;
+	this->m_progressRing->IsActive = true;
+	this->m_stepText->Text = "Closing...";
 
-	concurrency::create_task(concurrency::create_async([that, progressToken]() {
-		try {
-			if (that->m_main) {
-				that->m_main->CloseApp();
-			}
-		} catch (...) {
-		}
-	})).then([that, progressToken](concurrency::task<void> t) {
-		try {
-			t.get();
-
-			// UI is sent back to HostSelectorPage in StartRenderLoop(), after the loop exits
-			// All we need to do is close the progress dialog
-
-			DISPATCH_UI([progressToken] {
-				::moonlight_xbox_dx::ModalDialog::HideDialogByToken(progressToken);
-			});
-		} catch (...) {
-		}
-	});
+	this->m_main->RequestDisconnectAndClose();
 }
 
 void StreamPage::Keyboard_OnKeyDown(KeyboardControl^ sender, KeyEvent^ e)

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -24,6 +24,14 @@ namespace moonlight_xbox_dx {
 		bool enableKeyboard = false;
 		bool shouldAutoConnect = false;
 
+		// Protocol (URI scheme) launch support, filled by App::OnActivated
+		bool pendingProtocolHostSelect = false;
+		std::wstring pendingProtocolHost;
+		int pendingProtocolAppId = -1;
+		std::wstring pendingProtocolAppName;
+		bool pendingProtocolResume = false;
+		Platform::String^ launchOnExitUri;
+
 		bool WakeHost(MoonlightHost^ host);
 		void Validate_WoL(MoonlightHost^ host);
 		std::string WoL_Payload(std::string macAddress);

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -24,7 +24,6 @@ namespace moonlight_xbox_dx {
 		bool enableKeyboard = false;
 		bool shouldAutoConnect = false;
 
-		// Protocol (URI scheme) launch support, filled by App::OnActivated
 		bool pendingProtocolHostSelect = false;
 		std::wstring pendingProtocolHost;
 		int pendingProtocolAppId = -1;

--- a/State/MoonlightClient.cpp
+++ b/State/MoonlightClient.cpp
@@ -197,7 +197,11 @@ MoonlightClient::~MoonlightClient() {
 }
 
 void MoonlightClient::StopApp() {
-	gs_quit_app(&serverData);
+	int status = gs_quit_app(&serverData);
+	if (status != GS_OK) {
+		Utils::Logf("MoonlightClient::StopApp failed with status %d: %s\n",
+		            status, gs_error != nullptr ? gs_error : "Unknown error");
+	}
 }
 int MoonlightClient::StartStreaming(std::shared_ptr<DX::DeviceResources> res, StreamConfiguration^ sConfig) {
 	g_connectionTerminated.store(false, std::memory_order_release);

--- a/Streaming/moonlight_xbox_dxMain.cpp
+++ b/Streaming/moonlight_xbox_dxMain.cpp
@@ -28,10 +28,10 @@ extern "C" {
 
 // Loads and initializes application assets when the application is loaded.
 moonlight_xbox_dxMain::moonlight_xbox_dxMain(const std::shared_ptr<DX::DeviceResources> &deviceResources, StreamPage ^ streamPage, MoonlightClient *client, StreamConfiguration ^ configuration)
-    : m_deviceResources(deviceResources),
+    : moonlightClient(client),
+      m_deviceResources(deviceResources),
       m_pointerLocationX(0.0f),
-      m_streamPage(streamPage),
-      moonlightClient(client) {
+      m_streamPage(streamPage) {
 
 	Platform::String ^ appName = configuration->appName ? "'" + configuration->appName + "'" : "App";
 	DISPATCH_UI(([streamPage, appName]() {
@@ -326,8 +326,12 @@ void moonlight_xbox_dxMain::StartRenderLoop() {
 		StopRenderLoop(); // also stops input
 		Disconnect();
 
-		DISPATCH_UI([this]() {
-			ExitStreamPage();
+		if (m_quitAppAfterDisconnect.exchange(false, std::memory_order_acq_rel)) {
+			CloseApp();
+		}
+
+		DISPATCH_UI([]() {
+			moonlight_xbox_dxMain::ExitStreamPage();
 		});
 	});
 	m_renderLoopWorker = ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::TimeSliced);
@@ -865,13 +869,18 @@ void moonlight_xbox_dxMain::Disconnect() {
 	m_sceneRenderer->Stop();
 }
 
+void moonlight_xbox_dxMain::RequestDisconnectAndClose() {
+	if (!m_quitAppAfterDisconnect.exchange(true, std::memory_order_acq_rel)) {
+		moonlightClient->SetConnectionTerminated();
+	}
+}
+
 void moonlight_xbox_dxMain::CloseApp() {
 	moonlightClient->StopApp();
 }
 
 void moonlight_xbox_dxMain::ExitStreamPage() {
 
-	// If a frontend launched us with a launchOnExit return URI, go back to it and exit
 	auto state = GetApplicationState();
 	Platform::String ^ returnUri = state->launchOnExitUri;
 	if (returnUri != nullptr && !returnUri->IsEmpty()) {
@@ -892,7 +901,6 @@ void moonlight_xbox_dxMain::ExitStreamPage() {
 		} catch (...) {
 			Utils::Log("ExitStreamPage: the return URI is not a valid URI\n");
 		}
-		// Keep navigating back below so the app is in a sane state if the launch fails
 	}
 
 	bool reachedAppPage = false;

--- a/Streaming/moonlight_xbox_dxMain.cpp
+++ b/Streaming/moonlight_xbox_dxMain.cpp
@@ -871,6 +871,30 @@ void moonlight_xbox_dxMain::CloseApp() {
 
 void moonlight_xbox_dxMain::ExitStreamPage() {
 
+	// If a frontend launched us with a launchOnExit return URI, go back to it and exit
+	auto state = GetApplicationState();
+	Platform::String ^ returnUri = state->launchOnExitUri;
+	if (returnUri != nullptr && !returnUri->IsEmpty()) {
+		state->launchOnExitUri = nullptr;
+		try {
+			auto uri = ref new Windows::Foundation::Uri(returnUri);
+			concurrency::create_task(Windows::System::Launcher::LaunchUriAsync(uri)).then([](concurrency::task<bool> t) {
+				try {
+					if (t.get()) {
+						Windows::ApplicationModel::Core::CoreApplication::Exit();
+					} else {
+						Utils::Log("ExitStreamPage: failed to launch the return URI\n");
+					}
+				} catch (...) {
+					Utils::Log("ExitStreamPage: failed to launch the return URI\n");
+				}
+			});
+		} catch (...) {
+			Utils::Log("ExitStreamPage: the return URI is not a valid URI\n");
+		}
+		// Keep navigating back below so the app is in a sane state if the launch fails
+	}
+
 	bool reachedAppPage = false;
 
 	try {

--- a/Streaming/moonlight_xbox_dxMain.h
+++ b/Streaming/moonlight_xbox_dxMain.h
@@ -5,7 +5,11 @@
 #include "Streaming\VideoRenderer.h"
 #include "Streaming\LogRenderer.h"
 #include "Streaming\StatsRenderer.h"
-#include "Pages\StreamPage.xaml.h"
+
+namespace moonlight_xbox_dx
+{
+	ref class StreamPage;
+}
 
 // Xbox supports 8 controllers, this ought to be enough for anyone.
 #define MAX_GAMEPADS 8
@@ -32,8 +36,9 @@ namespace moonlight_xbox_dx
 		virtual void OnDeviceLost();
 		virtual void OnDeviceRestored();
 		void Disconnect();
+		void RequestDisconnectAndClose();
 		void CloseApp();
-		void ExitStreamPage();
+		static void ExitStreamPage();
 		void SendGuideButton(int duration);
 		void SendWinAltB();
 		bool ToggleLogs();
@@ -66,6 +71,7 @@ namespace moonlight_xbox_dx
 		float m_pointerLocationX;
 		bool insideFlyout = false;
 		StreamPage^ m_streamPage;
+		std::atomic<bool> m_quitAppAfterDisconnect{ false };
 
 		// Gamepad handling
 		std::array<GamepadState, MAX_GAMEPADS> m_GamepadState;

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -27,8 +27,10 @@
 #include <Limelight.h>
 
 #include <sys/stat.h>
+#include <errno.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <curl/curl.h>
 #ifdef _WIN32
@@ -833,28 +835,111 @@ int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, b
 
 int gs_quit_app(PSERVER_DATA server) {
   int ret = GS_OK;
+  int length;
+  long parsedCurrentGame;
   char url[4096];
+  char* currentGameEnd = NULL;
   uuid_t uuid;
   char uuid_str[UUID_STRLEN];
   char* result = NULL;
+  char* currentGameText = NULL;
+  char* stateText = NULL;
+  const char* busySuffix = "_SERVER_BUSY";
+  CURL* curl = NULL;
   PHTTP_DATA data = http_create_data();
   if (data == NULL)
     return GS_OUT_OF_MEMORY;
 
+  if (server == NULL || server->serverInfo.address == NULL || server->httpsPort == 0) {
+    gs_error = "Invalid host state for the quit request";
+    ret = GS_INVALID;
+    goto cleanup;
+  }
+
   uuid_generate_random(&uuid);
   uuid_unparse(&uuid, uuid_str);
-  snprintf(url, sizeof(url), "https://%s:%u/cancel?uniqueid=%s&uuid=%s", server->serverInfo.address, server->httpsPort, unique_id, uuid_str);
-  CURL* curl = get_curl_handle();
+  length = snprintf(url, sizeof(url), "https://%s:%u/cancel?uniqueid=%s&uuid=%s",
+                    server->serverInfo.address, server->httpsPort, unique_id, uuid_str);
+  if (length < 0 || (size_t)length >= sizeof(url)) {
+    gs_error = "Quit request URL is too long";
+    ret = GS_INVALID;
+    goto cleanup;
+  }
+
+  curl = get_curl_handle();
+  if (curl == NULL) {
+    ret = GS_OUT_OF_MEMORY;
+    goto cleanup;
+  }
+
+  curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 5000L);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 30000L);
   if ((ret = http_request(curl, url, data)) != GS_OK)
     goto cleanup;
 
-  if ((ret = xml_status(data->memory, data->size) != GS_OK))
+  ret = xml_status(data->memory, data->size);
+  if (ret != GS_OK)
     goto cleanup;
-  else if ((ret = xml_search(data->memory, data->size, "cancel", &result)) != GS_OK)
+
+  ret = xml_search(data->memory, data->size, "cancel", &result);
+  if (ret != GS_OK)
     goto cleanup;
 
   if (strcmp(result, "0") == 0) {
+    gs_error = "The host rejected the quit request";
     ret = GS_FAILED;
+    goto cleanup;
+  }
+
+  // Confirm the host no longer reports a running app.
+  uuid_generate_random(&uuid);
+  uuid_unparse(&uuid, uuid_str);
+  length = snprintf(url, sizeof(url), "https://%s:%u/serverinfo?uniqueid=%s&uuid=%s",
+                    server->serverInfo.address, server->httpsPort, unique_id, uuid_str);
+  if (length < 0 || (size_t)length >= sizeof(url)) {
+    ret = GS_INVALID;
+    goto cleanup;
+  }
+
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 10000L);
+  if ((ret = http_request(curl, url, data)) != GS_OK)
+    goto cleanup;
+
+  ret = xml_status(data->memory, data->size);
+  if (ret != GS_OK)
+    goto cleanup;
+
+  ret = xml_search(data->memory, data->size, "currentgame", &currentGameText);
+  if (ret != GS_OK)
+    goto cleanup;
+
+  ret = xml_search(data->memory, data->size, "state", &stateText);
+  if (ret != GS_OK)
+    goto cleanup;
+
+  if (currentGameText[0] == '\0' || stateText[0] == '\0') {
+    gs_error = "The host returned incomplete state after the quit request";
+    ret = GS_INVALID;
+    goto cleanup;
+  }
+
+  errno = 0;
+  parsedCurrentGame = strtol(currentGameText, &currentGameEnd, 10);
+  if (errno == ERANGE || currentGameEnd == currentGameText || *currentGameEnd != '\0' ||
+      parsedCurrentGame < 0 || parsedCurrentGame > INT_MAX) {
+    gs_error = "The host returned an invalid current game after the quit request";
+    ret = GS_INVALID;
+    goto cleanup;
+  }
+
+  size_t stateLength = strlen(stateText);
+  size_t suffixLength = strlen(busySuffix);
+  bool serverBusy = stateLength >= suffixLength &&
+                    strcmp(stateText + stateLength - suffixLength, busySuffix) == 0;
+  server->currentGame = serverBusy ? (int)parsedCurrentGame : 0;
+  if (server->currentGame != 0) {
+    gs_error = "The host is still reporting a running app after the quit request";
+    ret = GS_WRONG_STATE;
     goto cleanup;
   }
 
@@ -862,8 +947,15 @@ int gs_quit_app(PSERVER_DATA server) {
   if (result != NULL)
     free(result);
 
+  if (currentGameText != NULL)
+    free(currentGameText);
+
+  if (stateText != NULL)
+    free(stateText);
+
   http_free_data(data);
-  http_cleanup(curl);
+  if (curl != NULL)
+    http_cleanup(curl);
   return ret;
 }
 


### PR DESCRIPTION
Register the 'moonlight' URI protocol and handle protocol activations. Adds App::OnActivated and URI parsing to accept parameters (host, appId, appName, desktop, resume, launchOnExit) and a truthy flag parser. New ApplicationState fields track pending protocol host/app/resume and a launchOnExit URI. HostSelectorPage gains HandleProtocolHostSelect to resolve and auto-connect saved hosts; AppPage applies pending app/connect requests after apps are fetched. Streaming exit now launches the return URI (launchOnExit) if provided. Ensures cold-start behavior and avoids interrupting an active stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening `moonlight:` links to select a host and launch a specific application.
  * Supports host selection by saved name, identifier, hostname, or IP address.
  * Added resume-session requests and optional links that open automatically when streaming ends.
  * Reuses the existing app window and navigates to the appropriate host or application.

* **Bug Fixes**
  * Malformed, unavailable, or invalid activation requests are safely ignored.
  * Activation requests no longer interrupt an active stream.
  * Improved disconnect handling and verification that streaming applications have stopped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->