### PR TITLE
feat(input): add Share button quick menu actions

### DIFF
--- a/Pages/StreamPage.xaml
+++ b/Pages/StreamPage.xaml
@@ -47,6 +47,16 @@
                                     <FontIcon Glyph="&#xe80f;" />
                                 </MenuFlyoutItem.Icon>
                             </MenuFlyoutItem>
+                            <MenuFlyoutItem x:Name="shareButtonShort" Text="Share Button (short)" Click="shareButtonShort_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE898;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
+                            <MenuFlyoutItem x:Name="shareButtonLong" Text="Share Button (long)" Click="shareButtonLong_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
+                                <MenuFlyoutItem.Icon>
+                                    <FontIcon Glyph="&#xE898;" />
+                                </MenuFlyoutItem.Icon>
+                            </MenuFlyoutItem>
                             <MenuFlyoutItem x:Name="toggleHDR_WinAltB" Text="Toggle HDR (Win-Alt-B)" Click="toggleHDR_WinAltB_Click" AllowFocusOnInteraction="false" FocusVisualSecondaryThickness="0.5" >
                                 <MenuFlyoutItem.Icon>
                                     <FontIcon Glyph="&#xe706;" />

--- a/Pages/StreamPage.xaml.cpp
+++ b/Pages/StreamPage.xaml.cpp
@@ -319,6 +319,18 @@ void StreamPage::guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xa
 }
 
 
+void StreamPage::shareButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	this->m_main->SendShareButton(500);
+}
+
+
+void StreamPage::shareButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+	this->m_main->SendShareButton(3000);
+}
+
+
 void StreamPage::toggleHDR_WinAltB_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
 	this->m_main->SendWinAltB();

--- a/Pages/StreamPage.xaml.cpp
+++ b/Pages/StreamPage.xaml.cpp
@@ -161,7 +161,15 @@ void StreamPage::flyoutButton_Click(Platform::Object^ sender, Windows::UI::Xaml:
 
 void StreamPage::ActionsFlyout_Closed(Platform::Object^ sender, Platform::Object^ e)
 {
-	if (m_main != nullptr) m_main->SetFlyoutOpened(false);
+	const int shareButtonDuration = m_pendingShareButtonDuration;
+	m_pendingShareButtonDuration = 0;
+
+	if (m_main != nullptr) {
+		m_main->SetFlyoutOpened(false);
+		if (shareButtonDuration > 0) {
+			m_main->SendShareButton(shareButtonDuration);
+		}
+	}
 }
 
 void StreamPage::toggleMouseButton_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
@@ -321,13 +329,15 @@ void StreamPage::guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xa
 
 void StreamPage::shareButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
-	this->m_main->SendShareButton(500);
+	m_pendingShareButtonDuration = 500;
+	ActionsFlyout->Hide();
 }
 
 
 void StreamPage::shareButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
 {
-	this->m_main->SendShareButton(3000);
+	m_pendingShareButtonDuration = 3000;
+	ActionsFlyout->Hide();
 }
 
 

--- a/Pages/StreamPage.xaml.h
+++ b/Pages/StreamPage.xaml.h
@@ -164,6 +164,7 @@ namespace moonlight_xbox_dx
 		void Keyboard_OnKeyUp(moonlight_xbox_dx::KeyboardControl^ sender, moonlight_xbox_dx::KeyEvent^ e);
 		void guideButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		int m_pendingShareButtonDuration = 0;
 		void shareButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void shareButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void toggleHDR_WinAltB_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/Pages/StreamPage.xaml.h
+++ b/Pages/StreamPage.xaml.h
@@ -164,6 +164,8 @@ namespace moonlight_xbox_dx
 		void Keyboard_OnKeyUp(moonlight_xbox_dx::KeyboardControl^ sender, moonlight_xbox_dx::KeyEvent^ e);
 		void guideButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void guideButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void shareButtonShort_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+		void shareButtonLong_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void toggleHDR_WinAltB_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void resetDecoder_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 		void toggleFramePacing_Click(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A port of [Moonlight Stream](https://moonlight-stream.org/) for playing games us
 - Application List fetching
 - Video Streaming (configurable on a host-basis in the settings)
 - Gamepad Input (with Rumble and a mouse mode to move the pointer using the gamepad)
+- In-stream quick menu (press View + Menu) with short and long Guide/Share actions
 - Keyboard (both on-screen and using an Hardware one)
 - Graceful Disconnection
 - Host configuration (for resolution and bitrate) and saved host history

--- a/State/GamepadState.h
+++ b/State/GamepadState.h
@@ -31,10 +31,12 @@ struct GamepadState {
 	int64_t lastRefreshedQpc;                   // timestamp of last refresh
 	bool didSendArrival;                        // do we need to send LiSendControllerArrivalEvent?
 	std::atomic<bool> isGuideButtonDown{false}; // are we currently holding down the (virtual) Guide button?
+	std::atomic<bool> isShareButtonDown{false}; // are we currently holding down the (virtual) Share button?
 
 	Windows::Gaming::Input::GamepadReading reading;
 	Windows::Gaming::Input::GamepadReading previousReading;
 	bool previousGuideButtonDown;
+	bool previousShareButtonDown;
 	GamepadComboState combo;
 
 	short ltX, ltY, rtX, rtY;   // after a call to normalizeAxes() these are
@@ -74,7 +76,9 @@ struct GamepadState {
 		lastRefreshedQpc = 0;
 		didSendArrival = false;
 		isGuideButtonDown.store(false);
+		isShareButtonDown.store(false);
 		previousGuideButtonDown = false;
+		previousShareButtonDown = false;
 		reading = EmptyReading();
 		previousReading = EmptyReading();
 		ltX = ltY = rtX = rtY = 0;
@@ -104,6 +108,14 @@ struct GamepadState {
 
 	bool GetGuideButtonDown() {
 		return isGuideButtonDown.load();
+	}
+
+	void SetShareButtonDown(bool isDown) {
+		isShareButtonDown.store(isDown);
+	}
+
+	bool GetShareButtonDown() {
+		return isShareButtonDown.load();
 	}
 
 	ComboResult GetComboResult(int comboTimeoutMs) {
@@ -276,6 +288,12 @@ struct GamepadState {
 			return true;
 		}
 
+		bool shareButtonDown = isShareButtonDown.load();
+		if (shareButtonDown != previousShareButtonDown) {
+			previousShareButtonDown = shareButtonDown;
+			return true;
+		}
+
 		return false;
 	}
 
@@ -333,10 +351,11 @@ struct GamepadState {
 		char buttons[128];
 		DumpButtons(reading.Buttons, buttons, sizeof(buttons));
 		moonlight_xbox_dx::Utils::Logf(
-		    "GamepadState[localId: %d, hostId: %d] buttons: %s %s axes: %d %d, %d %d, triggers: %d %d, combo{ state: %d, viewPressed: %d, menuPressed: %d, startTime: %d }\n",
+		    "GamepadState[localId: %d, hostId: %d] buttons: %s %s %s axes: %d %d, %d %d, triggers: %d %d, combo{ state: %d, viewPressed: %d, menuPressed: %d, startTime: %d }\n",
 		    localId, hostId,
 		    buttons,
 		    isGuideButtonDown.load() ? "Guide" : "",
+		    isShareButtonDown.load() ? "Share" : "",
 		    ltX, ltY, rtX, rtY,
 		    lTrig, rTrig,
 		    combo.comboState, combo.viewPressed, combo.menuPressed, combo.startTime);

--- a/Streaming/moonlight_xbox_dxMain.cpp
+++ b/Streaming/moonlight_xbox_dxMain.cpp
@@ -529,6 +529,7 @@ void moonlight_xbox_dxMain::ProcessInput() {
 	auto gamepads = Windows::Gaming::Input::Gamepad::Gamepads;
 	uint16_t gamepadCount = gamepads->Size;
 	moonlightClient->SetGamepadCount(gamepadCount);
+	UpdateShareButton();
 
 	for (UINT i = 0; i < gamepadCount; i++) {
 		auto &state = this->FindGamepadState(i);
@@ -688,11 +689,6 @@ void moonlight_xbox_dxMain::ProcessInput() {
 void moonlight_xbox_dxMain::SetGuideButtonDown(uint32_t hostId, bool isDown) {
 	auto &state = FindGamepadStateByHostId(hostId);
 	state.SetGuideButtonDown(isDown);
-}
-
-void moonlight_xbox_dxMain::SetShareButtonDown(uint32_t hostId, bool isDown) {
-	auto &state = FindGamepadStateByHostId(hostId);
-	state.SetShareButtonDown(isDown);
 }
 
 uint16_t moonlight_xbox_dxMain::MakeActiveMask() {
@@ -935,15 +931,9 @@ void moonlight_xbox_dxMain::SendGuideButton(int duration) {
 }
 
 void moonlight_xbox_dxMain::SendShareButton(int duration) {
-	concurrency::create_async([duration, this]() {
-		// We change the state of the fake Share button, which will be included in the regular controller packets
-		auto &state = FindFirstGamepad();
-		SetShareButtonDown(state.hostId, true);
-
-		Sleep(duration);
-
-		SetShareButtonDown(state.hostId, false);
-	});
+	if (duration > 0) {
+		m_pendingShareButtonDuration.store(duration, std::memory_order_release);
+	}
 }
 
 void moonlight_xbox_dxMain::SendWinAltB() {
@@ -1027,6 +1017,47 @@ GamepadState &moonlight_xbox_dxMain::FindFirstGamepad() {
 
 	static GamepadState nullState;
 	return nullState;
+}
+
+void moonlight_xbox_dxMain::UpdateShareButton() {
+	const int64_t now = QpcNow();
+
+	if (m_shareButtonGamepad != nullptr) {
+		auto &state = FindGamepadStateByGamepad(m_shareButtonGamepad);
+		if (state.controller != m_shareButtonGamepad) {
+			m_shareButtonGamepad = nullptr;
+			m_shareButtonReleaseQpc = 0;
+		} else if (now >= m_shareButtonReleaseQpc) {
+			state.SetShareButtonDown(false);
+			m_shareButtonGamepad = nullptr;
+			m_shareButtonReleaseQpc = 0;
+		}
+	}
+
+	const int duration = m_pendingShareButtonDuration.exchange(0, std::memory_order_acq_rel);
+	if (duration <= 0) {
+		return;
+	}
+
+	auto &state = FindFirstGamepad();
+	if (state.controller == nullptr) {
+		return;
+	}
+
+	const int64_t releaseQpc = now + MsToQpc(duration);
+	if (m_shareButtonGamepad != state.controller) {
+		if (m_shareButtonGamepad != nullptr) {
+			auto &previousState = FindGamepadStateByGamepad(m_shareButtonGamepad);
+			if (previousState.controller == m_shareButtonGamepad) {
+				previousState.SetShareButtonDown(false);
+			}
+		}
+		m_shareButtonGamepad = state.controller;
+		m_shareButtonReleaseQpc = releaseQpc;
+	} else {
+		m_shareButtonReleaseQpc = std::max(m_shareButtonReleaseQpc, releaseQpc);
+	}
+	state.SetShareButtonDown(true);
 }
 
 void moonlight_xbox_dxMain::SendGamepadReadingForState(GamepadState &state, GamepadReading &reading) {

--- a/Streaming/moonlight_xbox_dxMain.cpp
+++ b/Streaming/moonlight_xbox_dxMain.cpp
@@ -690,6 +690,11 @@ void moonlight_xbox_dxMain::SetGuideButtonDown(uint32_t hostId, bool isDown) {
 	state.SetGuideButtonDown(isDown);
 }
 
+void moonlight_xbox_dxMain::SetShareButtonDown(uint32_t hostId, bool isDown) {
+	auto &state = FindGamepadStateByHostId(hostId);
+	state.SetShareButtonDown(isDown);
+}
+
 uint16_t moonlight_xbox_dxMain::MakeActiveMask() {
 	uint16_t activeMask = 0;
 	for (int i = 0; i < MAX_GAMEPADS; ++i) {
@@ -777,7 +782,9 @@ void moonlight_xbox_dxMain::SendGamepadArrival(GamepadState &state) {
 	if (state.didSendArrival) return;
 
 	uint8_t type = IsXbox() ? LI_CTYPE_XBOX : LI_CTYPE_UNKNOWN;
-	uint32_t supportedButtonFlags = A_FLAG | B_FLAG | X_FLAG | Y_FLAG | BACK_FLAG | PLAY_FLAG | LS_CLK_FLAG | RS_CLK_FLAG | UP_FLAG | DOWN_FLAG | LEFT_FLAG | RIGHT_FLAG | LB_FLAG | RB_FLAG;
+	uint32_t supportedButtonFlags =
+	    A_FLAG | B_FLAG | X_FLAG | Y_FLAG | BACK_FLAG | PLAY_FLAG | LS_CLK_FLAG | RS_CLK_FLAG |
+	    UP_FLAG | DOWN_FLAG | LEFT_FLAG | RIGHT_FLAG | LB_FLAG | RB_FLAG | MISC_FLAG;
 	uint32_t capabilities = LI_CCAP_ANALOG_TRIGGERS | LI_CCAP_RUMBLE | LI_CCAP_TRIGGER_RUMBLE;
 	int rc = LiSendControllerArrivalEvent(state.hostId, MakeActiveMask(), type, supportedButtonFlags, capabilities);
 	if (rc != 0) {
@@ -927,6 +934,18 @@ void moonlight_xbox_dxMain::SendGuideButton(int duration) {
 	});
 }
 
+void moonlight_xbox_dxMain::SendShareButton(int duration) {
+	concurrency::create_async([duration, this]() {
+		// We change the state of the fake Share button, which will be included in the regular controller packets
+		auto &state = FindFirstGamepad();
+		SetShareButtonDown(state.hostId, true);
+
+		Sleep(duration);
+
+		SetShareButtonDown(state.hostId, false);
+	});
+}
+
 void moonlight_xbox_dxMain::SendWinAltB() {
 	// Win-Alt-B = Toggle HDR
 	concurrency::create_async([this]() {
@@ -1032,9 +1051,12 @@ void moonlight_xbox_dxMain::SendGamepadReadingForState(GamepadState &state, Game
 			}
 		}
 
-		// add Guide button if it's being virtually held down by quick menu
+		// add virtual buttons held down by quick menu actions
 		if (state.GetGuideButtonDown()) {
 			buttonFlags |= SPECIAL_FLAG;
+		}
+		if (state.GetShareButtonDown()) {
+			buttonFlags |= MISC_FLAG;
 		}
 
 		LiSendMultiControllerEvent(

--- a/Streaming/moonlight_xbox_dxMain.h
+++ b/Streaming/moonlight_xbox_dxMain.h
@@ -70,13 +70,16 @@ namespace moonlight_xbox_dx
 
 		// Gamepad handling
 		std::array<GamepadState, MAX_GAMEPADS> m_GamepadState;
+		std::atomic<int> m_pendingShareButtonDuration{0};
+		Windows::Gaming::Input::Gamepad^ m_shareButtonGamepad = nullptr;
+		int64_t m_shareButtonReleaseQpc = 0;
 		GamepadState& FindGamepadState(uint32_t localId);
 		GamepadState& FindGamepadStateByHostId(uint32_t hostId);
 		GamepadState& FindGamepadStateByGamepad(Windows::Gaming::Input::Gamepad^ gamepad);
 		GamepadState& FindFirstGamepad();
 		uint16_t MakeActiveMask();
 		void SetGuideButtonDown(uint32_t hostId, bool isDown);
-		void SetShareButtonDown(uint32_t hostId, bool isDown);
+		void UpdateShareButton();
 		void DumpGamepads();
 		void RefreshGamepads();
 		void SendGamepadArrival(GamepadState& state);

--- a/Streaming/moonlight_xbox_dxMain.h
+++ b/Streaming/moonlight_xbox_dxMain.h
@@ -35,6 +35,7 @@ namespace moonlight_xbox_dx
 		void CloseApp();
 		void ExitStreamPage();
 		void SendGuideButton(int duration);
+		void SendShareButton(int duration);
 		void SendWinAltB();
 		bool ToggleLogs();
 		bool ToggleStats();
@@ -75,6 +76,7 @@ namespace moonlight_xbox_dx
 		GamepadState& FindFirstGamepad();
 		uint16_t MakeActiveMask();
 		void SetGuideButtonDown(uint32_t hostId, bool isDown);
+		void SetShareButtonDown(uint32_t hostId, bool isDown);
 		void DumpGamepads();
 		void RefreshGamepads();
 		void SendGamepadArrival(GamepadState& state);


### PR DESCRIPTION
Expose short and long Share button presses in the in-stream quick menu and wire them through the virtual gamepad state so controller packets can send MISC/Share input. This also advertises Share support during controller arrival and updates the README to document the new quick menu actions and Sunshine requirement.

Passing the Xbox Share button is something https://github.com/LizardByte/libvirtualhid/pull/118 and https://github.com/LizardByte/Sunshine/pull/5585 has/will fix for Linux. Still not working on Windows side though.

PR Tested and working in dev mode on Series X and One X. **Should squash and merge both commits into one**. Second commit addressed code rabbit suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added short-press and long-press Share actions to the in-stream quick menu.
  * Share button presses are now transmitted during streaming, including button state changes.
  * Added support for triggering Share actions from the controller interface.
  * Share actions continue to work reliably when controllers connect or disconnect during streaming.
* **Documentation**
  * Updated the feature list with quick-menu Guide and Share actions.
  * Noted that Share functionality requires Sunshine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->