### PR TITLE
feat(ui): add a Game Tile Size setting for the app grid

### DIFF
--- a/Pages/AppPage.xaml
+++ b/Pages/AppPage.xaml
@@ -62,8 +62,8 @@
             <GridView.ItemTemplate>
                 <DataTemplate x:DataType="local:MoonlightApp" x:DefaultBindMode="OneWay">
                     <StackPanel>
-                        <StackPanel Padding="16" VerticalAlignment="Center">
-                            <Image Source="{x:Bind ImagePath}" Stretch="Fill" Height="300" Width="225"/>
+                        <StackPanel Padding="{x:Bind TilePadding}" VerticalAlignment="Center">
+                            <Image Source="{x:Bind ImagePath}" Stretch="Fill" Height="{x:Bind TileHeight}" Width="{x:Bind TileWidth}"/>
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Stretch">
                                 <Image Source="ms-appx:///Assets/play.svg" Visibility="{x:Bind CurrentlyRunning}" Width="24" Height="24" />
                                 <TextBlock Text="{x:Bind Name}"></TextBlock>

--- a/Pages/AppPage.xaml.cpp
+++ b/Pages/AppPage.xaml.cpp
@@ -57,6 +57,15 @@ void AppPage::OnNavigatedTo(Windows::UI::Xaml::Navigation::NavigationEventArgs^ 
 	host->UpdateHostInfo(true);
 	host->UpdateApps();
 
+	// Tile size may have been changed in Settings while we were away.
+	if (host->Apps != nullptr) {
+		for (auto a : host->Apps) {
+			a->OnPropertyChanged("TileWidth");
+			a->OnPropertyChanged("TileHeight");
+			a->OnPropertyChanged("TilePadding");
+		}
+	}
+
 	// Start background polling for app running state and connectivity
 	continueAppFetch.store(true);
 	wasConnected.store(host->Connected);

--- a/Pages/MoonlightSettings.xaml
+++ b/Pages/MoonlightSettings.xaml
@@ -58,7 +58,9 @@
                 <ComboBox XYFocusLeft="{x:Bind KeyboardEnable}" Grid.Column="7" Grid.Row="0" x:Name="KeyboardLayoutSelector" SelectionChanged="LayoutSelector_SelectionChanged"></ComboBox>
                 <TextBlock>Layout</TextBlock>
             </StackPanel>
-            <Button x:Name="WelcomeButton" Grid.Row="7" Grid.Column="1" Click="WelcomeButton_Click">Open Welcome Wizard</Button>
+            <TextBlock Grid.Column="0" Grid.Row="7">Game Tile Size:</TextBlock>
+            <Slider Grid.Row="7" Grid.Column="1" Value="{x:Bind State.TileScale}" x:DefaultBindMode="TwoWay" Minimum="25" Maximum="150" StepFrequency="5"/>
+            <Button x:Name="WelcomeButton" Grid.Row="8" Grid.Column="1" Click="WelcomeButton_Click">Open Welcome Wizard</Button>
         </Grid>
     </StackPanel>
 </Page>

--- a/State/ApplicationState.cpp
+++ b/State/ApplicationState.cpp
@@ -29,6 +29,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::Init()
 				if (stateJson.contains("marginWidth"))this->ScreenMarginWidth = stateJson["marginWidth"];
 				if (stateJson.contains("marginHeight"))this->ScreenMarginHeight = stateJson["marginHeight"];
 				if (stateJson.contains("mouseSensitivity"))this->MouseSensitivity = stateJson["mouseSensitivity"];
+				if (stateJson.contains("tileScale"))this->TileScale = stateJson["tileScale"];
 				if (stateJson.contains("alternateCombination")) this->AlternateCombination = stateJson["alternateCombination"].get<bool>();
 				for (auto a : stateJson["hosts"]) {
 					MoonlightHost^ h = ref new MoonlightHost(Utils::StringFromStdString(a["hostname"].get<std::string>()));
@@ -87,6 +88,7 @@ Concurrency::task<void> moonlight_xbox_dx::ApplicationState::UpdateFile()
 		stateJson["marginWidth"] = std::max(0, std::min(that->ScreenMarginWidth, 250));
 		stateJson["marginHeight"] = std::max(0, std::min(that->ScreenMarginHeight, 250));
 		stateJson["mouseSensitivity"] = std::max(1, std::min(that->MouseSensitivity, 16));
+		stateJson["tileScale"] = std::max(25, std::min(that->TileScale, 150));
 		stateJson["firstTime"] = that->FirstTime;
 		stateJson["enableKeyboard"] = that->EnableKeyboard;
 		stateJson["keyboardLayout"] = Utils::PlatformStringToStdString(that->KeyboardLayout);

--- a/State/ApplicationState.h
+++ b/State/ApplicationState.h
@@ -12,6 +12,7 @@ namespace moonlight_xbox_dx {
 		int screenMarginW;
 		int screenMarginH;
 		int mouseSensitivity = 3;
+		int tileScale = 100;
 		Platform::String^ keyboardLayout;
 		bool firstTime;
 		bool alternateCombination;
@@ -92,6 +93,46 @@ namespace moonlight_xbox_dx {
 			void set(int value) {
 				this->mouseSensitivity = value;
 				OnPropertyChanged("MouseSensitivity");
+			}
+		}
+
+		// Size of the game tiles on the app grid, as a percentage of the
+		// original 225x300 artwork box. 100 leaves the grid unchanged.
+		property int TileScale
+		{
+			int get()
+			{
+				return this->tileScale;
+			};
+			void set(int value) {
+				if (value < 25) value = 25;
+				if (value > 150) value = 150;
+				this->tileScale = value;
+				OnPropertyChanged("TileScale");
+				OnPropertyChanged("TileWidth");
+				OnPropertyChanged("TileHeight");
+				OnPropertyChanged("TilePadding");
+			}
+		}
+
+		property double TileWidth
+		{
+			double get() { return 225.0 * this->tileScale / 100.0; }
+		}
+
+		property double TileHeight
+		{
+			double get() { return 300.0 * this->tileScale / 100.0; }
+		}
+
+		// Keep the gap between tiles proportional so small tiles pack tightly.
+		property Windows::UI::Xaml::Thickness TilePadding
+		{
+			Windows::UI::Xaml::Thickness get()
+			{
+				double p = 16.0 * this->tileScale / 100.0;
+				if (p < 4.0) p = 4.0;
+				return { p, p, p, p };
 			}
 		}
 

--- a/State/MoonlightApp.cpp
+++ b/State/MoonlightApp.cpp
@@ -1,10 +1,26 @@
 #include "pch.h"
 #include "MoonlightApp.h"
 #include "State\MoonlightClient.h"
+#include "State\ApplicationState.h"
 #include <ppltasks.h>
 
 namespace moonlight_xbox_dx {
 	
+	double MoonlightApp::TileWidth::get()
+	{
+		return GetApplicationState()->TileWidth;
+	}
+
+	double MoonlightApp::TileHeight::get()
+	{
+		return GetApplicationState()->TileHeight;
+	}
+
+	Windows::UI::Xaml::Thickness MoonlightApp::TilePadding::get()
+	{
+		return GetApplicationState()->TilePadding;
+	}
+
 	void MoonlightApp::OnPropertyChanged(Platform::String^ propertyName)
 	{
 		Windows::ApplicationModel::Core::CoreApplication::MainView->CoreWindow->Dispatcher->RunAsync(

--- a/State/MoonlightApp.h
+++ b/State/MoonlightApp.h
@@ -43,6 +43,23 @@ namespace moonlight_xbox_dx {
             }
         }
 
+        // Tile geometry, read from the shared application state so each
+        // tile honours the user's tile-size setting.
+        property double TileWidth
+        {
+            double get();
+        }
+
+        property double TileHeight
+        {
+            double get();
+        }
+
+        property Windows::UI::Xaml::Thickness TilePadding
+        {
+            Windows::UI::Xaml::Thickness get();
+        }
+
         property bool CurrentlyRunning
         {
             bool get() { return this->currentlyRunning; }


### PR DESCRIPTION
The app grid hardcodes each tile's artwork box at `225x300` in `Pages/AppPage.xaml`, so how many games fit on screen is fixed. That's a lot of wasted space on a large TV, and it's been asked for a couple of times already — #279 and #283 both want it, from different angles.

This adds a **Game Tile Size** slider to Settings: 25%–150% of the original `225x300` box, default **100%**, so nothing moves for anyone who doesn't touch it.


### What it does

- Slider in Settings, row 7, alongside the existing Mouse Sensitivity / Screen Margin sliders. The settings `Grid` already declared 9 `RowDefinition`s while only rows 0–7 were used, so the Welcome Wizard button moves to row 8 and no row had to be added.
- Inter-tile padding scales with the setting and is floored at 4px, so small tiles actually pack tightly rather than drowning in the fixed 16px gutter.
- `Stretch="Fill"` was already on the `Image`, so source artwork resolution is unaffected.

### How it's wired

`tileScale` lives on `ApplicationState` and persists to `state.json`, clamped to 25–150 on both load and save (matching how `mouseSensitivity` is handled).

The one non-obvious bit: the tile lives inside a `DataTemplate` whose `x:DataType` is `MoonlightApp`, and `{x:Bind}` resolves against the `x:DataType`, not the page — it can't reach the page or the app state from inside that namescope. So the geometry is exposed as three read-through properties on `MoonlightApp` (`TileWidth`, `TileHeight`, `TilePadding`) that delegate to `GetApplicationState()`. `AppPage::OnNavigatedTo` re-raises those property-changed notifications so the grid picks up a new size when you return from Settings.

That does mean the size applies on navigating back to the grid rather than live while the slider is being dragged. That seemed like the right trade for not holding a back-reference from every item view model to the app state; happy to change it if you'd rather.

`Slider.Value` is a `double` bound TwoWay to an `int` property — that's not new, the adjacent `MouseSensitivity`, `ScreenMarginWidth` and `ScreenMarginHeight` sliders already do exactly this.

### Testing

Built the x64 Release `msixbundle` against the pinned vcpkg manifest — clean, no new warnings. Installed and exercised on a retail Series X via Device Portal.

### Unrelated, but worth flagging while I'm here

Building current `master` from a clean checkout fails, and it isn't this change. The `vcpkg_installed.zip` asset that `setup-dev.ps1` and the CI workflow download from the 1.10.0 release is stale: it ships libavformat 59.27.100 (FFmpeg 5.x) while `vcpkg.json` now pins ffmpeg 8.1.2#3 (libavformat 62.12.102). The mismatch surfaces as:

```
Streaming\FFmpegDecoder.cpp(636,21): error C2664: cannot convert argument 6
  from 'int (__cdecl *)(void *,const uint8_t *,int)'
  to   'int (__cdecl *)(void *,uint8_t *,int)'
```

Deleting the extracted tree and running `.\vcpkg\vcpkg.exe install --triplet x64-uwp` from the repo root fixes it with no source change (~2s, entirely from binary cache), because the `.vcxproj` references the libs unversioned and copies runtime DLLs by wildcard. Refreshing that release asset would save the next person the hunt. Separately, `setup-dev.ps1` reports a false MISSING on any VS **Build Tools** host, because it checks for `Microsoft.VisualStudio.ComponentGroup.UWP.VC`, which is IDE-SKU-only — the Build Tools equivalent is `...UWP.VC.BuildTools`, and the bootstrapper silently accepts and drops the IDE id with exit code 0.

Happy to split either of those into their own issue if you'd prefer them out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Game Tile Size** setting with an adjustable slider.
  - Tile dimensions, image sizes, and spacing now scale according to the selected setting.
  - Tile size preferences are saved and restored between sessions.

- **Bug Fixes**
  - App tiles now refresh automatically with updated sizing after returning to the app page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->