### PR TITLE
fix(capture): match FFmpeg AVIO write callback signature

### DIFF
--- a/Streaming/FFmpegDecoder.cpp
+++ b/Streaming/FFmpegDecoder.cpp
@@ -539,7 +539,7 @@ void FFMpegDecoder::DrainCaptureQueue() {
 }
 
 // ffmpeg writer
-int FFMpegDecoder::CaptureAvioWrite(void* opaque, const uint8_t* buf, int size) {
+int FFMpegDecoder::CaptureAvioWrite(void* opaque, uint8_t* buf, int size) {
 	auto* me = reinterpret_cast<FFMpegDecoder*>(opaque);
 	if (size <= 0) {
 		return 0;

--- a/Streaming/FFmpegDecoder.h
+++ b/Streaming/FFmpegDecoder.h
@@ -96,7 +96,7 @@ class FFMpegDecoder {
 	void CaptureWriteFrame(const CapturePacket &packet, uint32_t rtpTimestamp, bool isKeyFrame);
 	void CaptureClose();
 	void CaptureAbort();
-	static int CaptureAvioWrite(void *opaque, const uint8_t *buf, int size);
+	static int CaptureAvioWrite(void *opaque, uint8_t *buf, int size);
 
 	const AVCodec *decoder;
 	AVCodecContext *decoder_ctx;


### PR DESCRIPTION
FFmpeg's avio_alloc_context() expects a write callback with a mutable uint8_t* buffer. CaptureAvioWrite declared the buffer as const, making the function pointer incompatible with the installed FFmpeg headers and causing the MSVC build to fail.

Match FFmpeg's callback type in the declaration and definition. The buffer remains read-only in practice.

I had to do this for testing both https://github.com/TheElixZammuto/moonlight-xbox/pull/291 and https://github.com/TheElixZammuto/moonlight-xbox/pull/289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the media streaming pipeline by updating internal capture handling.
  * Preserved existing capture behavior, including write-failure reporting and successful byte handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->